### PR TITLE
Add double-tap gesture for play/pause on Apple Watch

### DIFF
--- a/AudioBooth/AudioBooth Watch App/Screens/Player/PlayerView.swift
+++ b/AudioBooth/AudioBooth Watch App/Screens/Player/PlayerView.swift
@@ -138,12 +138,22 @@ struct PlayerView: View {
       ProgressView()
         .controlSize(.regular)
     case .ready:
-      Button(
-        action: model.togglePlayback,
-        label: {
-          Image(systemName: model.isPlaying ? "pause.fill" : "play.fill")
-        }
-      )
+      if #available(watchOS 11.0, *) {
+        Button(
+          action: model.togglePlayback,
+          label: {
+            Image(systemName: model.isPlaying ? "pause.fill" : "play.fill")
+          }
+        )
+        .handGestureShortcut(.primaryAction)
+      } else {
+        Button(
+          action: model.togglePlayback,
+          label: {
+            Image(systemName: model.isPlaying ? "pause.fill" : "play.fill")
+          }
+        )
+      }
     case .error(let retryable):
       if retryable {
         Button(


### PR DESCRIPTION
## Summary
- Adds `.handGestureShortcut(.primaryAction)` to the play/pause button in the Watch app player
- Enables the watchOS 10+ double-tap gesture to toggle playback
- Uses `#available(watchOS 11.0, *)` check for backward compatibility with watchOS 10

## Test plan
- [x] Build and deploy to Apple Watch running watchOS 11+
- [x] Open the player with an audiobook
- [x] Perform the double-tap gesture (pinch thumb and index finger together twice)
- [x] Verify playback toggles between play and pause