### PR TITLE
Update shake sensitivity labels for clarity

### DIFF
--- a/AudioBooth/AudioBooth/Screens/Settings/Preferences/Player/PlayerPreferencesView.swift
+++ b/AudioBooth/AudioBooth/Screens/Settings/Preferences/Player/PlayerPreferencesView.swift
@@ -161,7 +161,7 @@ struct PlayerPreferencesView: View {
         }
         .font(.caption)
 
-        Picker("Shake to Reset", selection: $preferences.shakeSensitivity) {
+        Picker("Shake Sensitivity to Reset", selection: $preferences.shakeSensitivity) {
           Text("Off").tag(ShakeSensitivity.off)
           Text("Very Low").tag(ShakeSensitivity.veryLow)
           Text("Low").tag(ShakeSensitivity.low)


### PR DESCRIPTION
Renamed shake sensitivity options from technical sensitivity levels to intuitive gesture descriptions. The previous labels (Off, Very High, High, Medium, Low, Very Low) were confusing because "High" sensitivity required a gentle or low shaking strength while "Low" required a vigorous/a lot of shaking.

#### Files Changed
- `PlayerPreferencesView.swift`
- `UserPreferences.swift` - I hope that was correct, I am not sure what it is used for.


#### Alternative Options
If you don't like these labels, here are two alternatives:

Off, Barely a Tap, Light Shake, Normal Shake, Hard Shake, Very Hard Shake

Off, Ultra Sensitive, Very Sensitive, Sensitive, Less Sensitive, Least Sensitive
