### PR TITLE
Improve some German translations

### DIFF
--- a/AudioBooth/AudioBooth/Localizable.xcstrings
+++ b/AudioBooth/AudioBooth/Localizable.xcstrings
@@ -3620,7 +3620,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start"
+            "value": "Übersicht"
           }
         }
       }
@@ -5622,7 +5622,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Einstellungen"
+            "value": "Optionen"
           }
         }
       }


### PR DESCRIPTION
After looking through the app in German localization, I've realized that some labels have more suitable translations. Here are some minor adjustments. 