### PR TITLE
Updates to Author Sort

### DIFF
--- a/API/Sources/API/Models/Author.swift
+++ b/API/Sources/API/Models/Author.swift
@@ -3,6 +3,7 @@ import Foundation
 public struct Author: Codable, Sendable {
   public let id: String
   public let name: String
+  public let lastFirst: String
   public let description: String?
   public let addedAt: Date?
   public let updatedAt: Date?

--- a/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorCard/AuthorCard.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorCard/AuthorCard.swift
@@ -79,17 +79,20 @@ extension AuthorCard {
   @Observable class Model {
     var id: String
     var name: String
+    var lastFirst: String
     var bookCount: Int
     var imageURL: URL?
 
     init(
       id: String = UUID().uuidString,
       name: String = "",
+      lastFirst: String = "",
       bookCount: Int = 0,
       imageURL: URL? = nil
     ) {
       self.id = id
       self.name = name
+      self.lastFirst = lastFirst
       self.bookCount = bookCount
       self.imageURL = imageURL
     }

--- a/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorCard/AuthorCardModel.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorCard/AuthorCardModel.swift
@@ -6,6 +6,7 @@ final class AuthorCardModel: AuthorCard.Model {
     super.init(
       id: author.id,
       name: author.name,
+      lastFirst: author.lastFirst,
       bookCount: author.numBooks ?? 0,
       imageURL: author.imageURL
     )

--- a/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorSort.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorSort.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension String {
+  func cleaned() -> Self {
+    return self.folding(options: .diacriticInsensitive, locale: .current)
+  }
+}
+
+func sectionLetter(for name: String) -> String {
+  let cleanedName = name.cleaned()
+  guard let firstChar = cleanedName.uppercased().first else { return "#" }
+  let validLetters: Set<Character> = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+  return validLetters.contains(firstChar) ? String(firstChar) : "#"
+}

--- a/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorsPage.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorsPage.swift
@@ -67,9 +67,9 @@ struct AuthorsPage: View {
     let sortedAuthors = model.authors.sorted { lhs, rhs in
       switch sortOrder {
       case .firstLast:
-        return lhs.name < rhs.name
+        return lhs.name.cleaned().lowercased() < rhs.name.cleaned().lowercased()
       case .lastFirst:
-        return lastNameFirst(lhs.name) < lastNameFirst(rhs.name)
+        return lhs.lastFirst.cleaned().lowercased() < rhs.lastFirst.cleaned().lowercased()
       }
     }
 
@@ -79,7 +79,7 @@ struct AuthorsPage: View {
       case .firstLast:
         name = author.name
       case .lastFirst:
-        name = lastNameFirst(author.name)
+        name = author.lastFirst
       }
       return sectionLetter(for: name)
     }
@@ -91,18 +91,6 @@ struct AuthorsPage: View {
       if rhs.letter == "#" { return true }
       return lhs.letter < rhs.letter
     }
-  }
-
-  private func sectionLetter(for name: String) -> String {
-    guard let firstChar = name.uppercased().first else { return "#" }
-    let validLetters: Set<Character> = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-    return validLetters.contains(firstChar) ? String(firstChar) : "#"
-  }
-
-  private func lastNameFirst(_ name: String) -> String {
-    let components = name.components(separatedBy: " ")
-    guard components.count > 1 else { return name }
-    return components.last ?? name
   }
 
   var authorsRowContent: some View {

--- a/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorsPageModel.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorsPageModel.swift
@@ -4,7 +4,6 @@ import SwiftUI
 
 final class AuthorsPageModel: AuthorsPage.Model {
   private let audiobookshelf = Audiobookshelf.shared
-
   private var targetLetter: String?
 
   private var currentPage: Int = 0
@@ -38,12 +37,21 @@ final class AuthorsPageModel: AuthorsPage.Model {
 
     isLoadingNextPage = true
     isLoading = currentPage == 0
+      
+    @AppStorage("authorsPageSortOrder") var sortOrder: AuthorsPage.SortOrder = .firstLast
+    var sortBy: AuthorsService.SortBy
+    switch sortOrder {
+      case .firstLast:
+        sortBy = .name
+      case .lastFirst:
+        sortBy = .lastFirst
+    }
 
     do {
       let response = try await audiobookshelf.authors.fetch(
         limit: itemsPerPage,
         page: currentPage,
-        sortBy: .name,
+        sortBy: sortBy,
         ascending: true
       )
 
@@ -96,11 +104,7 @@ extension AuthorsPageModel {
     Set(authors.map { sectionLetter(for: $0.name) })
   }
 
-  private func sectionLetter(for name: String) -> String {
-    guard let firstChar = name.uppercased().first else { return "#" }
-    let validLetters: Set<Character> = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-    return validLetters.contains(firstChar) ? String(firstChar) : "#"
-  }
+
 
   private func findNextAvailableLetter(after letter: String, in sections: Set<String>) -> String? {
     if letter == "#" { return AuthorsPage.bottomScrollID }


### PR DESCRIPTION
These changes are in regards to the issues I raised in https://discord.com/channels/1448922368775950508/1478773072143061146 today.

This is my first time coding in Swift (I am a windows developer by day), but it tested correctly in the simulator.

- Replaced usage of lastNameFirst function with lastFirst field returned with from AudiobookShelf authors list.
- When sorting AuthorsPage by "Last First" call to audiobookshelf.authors.fetch sets sortBy to .lastFirst, as opposed to .name.
- Added .cleaned extention for String, that converts accented characters to their unaccented version.
- When comparing names for sort, do the comparison on cleaned, lowercased names.
- When finding sectionLetter, do so on the name.cleaned(), so names that start with accented characters are sorted with unaccented characters.