### PR TITLE
Fix Now Playing metadata for Bluetooth/USB car displays

### DIFF
--- a/AudioBooth/AudioBooth/Services/NowPlayingManager.swift
+++ b/AudioBooth/AudioBooth/Services/NowPlayingManager.swift
@@ -175,8 +175,8 @@ final class NowPlayingManager {
 
     if !preferences.showFullBookDuration, let chapters, let current = chapters.current {
       info[MPMediaItemPropertyTitle] = current.title
-      info[MPMediaItemPropertyArtist] = author
-      info[MPMediaItemPropertyAlbumTitle] = title
+      info[MPMediaItemPropertyArtist] = title
+      info[MPMediaItemPropertyAlbumTitle] = author
       info[MPMediaItemPropertyPlaybackDuration] = current.end - current.start
       info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = chapters.currentElapsedTime(
         currentTime: mediaProgress.currentTime


### PR DESCRIPTION
- #179

I found the bug in `NowPlayingManager.update()`. When showing per-chapter info, `MPMediaItemPropertyAlbumTitle` was never set, so car displays and Bluetooth AVRCP showed an empty album field. I added the author to `MPMediaItemPropertyAlbumTitle` in chapter mode so all three fields are populated for external displays.

When `showFullBookDuration` is on (full book mode), album title gets cleared so stale values don't carry over.

### Lock Screen (chapter duration)
<img width="450" alt="image" src="https://github.com/user-attachments/assets/b86197a6-566c-4257-a118-441f40c8177b"/>

### Lock Screen (book duration)
<img width="450" alt="image" src="https://github.com/user-attachments/assets/38611de9-fe14-467a-a72d-fe6f05cf0f14"/>

### CarPlay
#### Before
| Book duration | Chapter duration |
|--------|-------|
| <img width="450" alt="image" src="https://github.com/user-attachments/assets/16ad2489-adce-436d-aa48-6f13ef9b4d10"/> | <img width="450" alt="image" src="https://github.com/user-attachments/assets/eb20664d-a2b6-4562-94c5-824faf178051"/> |

#### After
| Book duration | Chapter duration |
|--------|-------|
| <img width="450" alt="image" src="https://github.com/user-attachments/assets/a03cb340-e8df-468f-9d12-13facacf3ce9"/> | <img width="450" alt="image" src="https://github.com/user-attachments/assets/185769fd-e4f7-4604-b9f5-5e246e44ae6c"/> |

I don't have a Bluetooth/USB car setup to test AVRCP directly, but it reads from the same `MPNowPlayingInfoCenter` dictionary so the data should be correct there too.