### PR TITLE
Fix crash when tapping author chip

### DIFF
--- a/AudioBooth/AudioBooth/Screens/BookDetails/BookDetailsView.swift
+++ b/AudioBooth/AudioBooth/Screens/BookDetails/BookDetailsView.swift
@@ -379,7 +379,7 @@ struct BookDetailsView: View {
           FlowLayout(spacing: 4) {
             ForEach(model.authors, id: \.id) { author in
               NavigationLink(
-                value: NavigationDestination.author(id: author.id, name: author.name, libraryID: model.libraryID)
+                value: NavigationDestination.authorLibrary(id: author.id, name: author.name, libraryID: model.libraryID)
               ) {
                 Chip(
                   title: author.name,


### PR DESCRIPTION
Fixes a crash when tapping the author chip in `BookDetailsView`.

The view was using `NavigationDestination.author`, but `LibraryPageModel`
only supports `NavigationDestination.authorLibrary`, causing a fatalError.

Thanks to @ninewalker on Discord for reporting the issue.