### PR TITLE
Fix playback failure when file codec doesn't match extension

### DIFF
--- a/API/Sources/API/Models/AudioTrack.swift
+++ b/API/Sources/API/Models/AudioTrack.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public struct AudioTrack: Codable, Sendable {
+  public let index: Int
+  public let startOffset: Double
+  public let duration: Double
+  public let title: String?
+  public let updatedAt: Date?
+  public let metadata: Metadata?
+  public let format: String?
+  public let bitRate: Int?
+  public let codec: String?
+  public let channels: Int?
+  public let channelLayout: String?
+  public let mimeType: String?
+  public let ino: String
+
+  public struct Metadata: Codable, Sendable {
+    public let filename: String?
+    public let ext: String?
+    public let size: Int64?
+  }
+}

--- a/API/Sources/API/Models/Book.swift
+++ b/API/Sources/API/Models/Book.swift
@@ -53,7 +53,7 @@ extension Book {
   public var duration: Double { media.duration ?? 0 }
   public var size: Int64? { media.size }
   public var chapters: [Media.Chapter]? { media.chapters }
-  public var tracks: [Media.Track]? { media.tracks }
+  public var tracks: [AudioTrack]? { media.tracks }
   public var tags: [String]? { media.tags }
 
   public struct MediaType: OptionSet, Sendable {
@@ -105,7 +105,7 @@ extension Book {
     public let size: Int64?
     public let numTracks: Int?
     public let chapters: [Chapter]?
-    public let tracks: [Track]?
+    public let tracks: [AudioTrack]?
     public let tags: [String]?
     public let ebookFile: LibraryFile?
     public let ebookFormat: String?
@@ -151,27 +151,6 @@ extension Book {
       public let title: String
     }
 
-    public struct Track: Codable, Sendable {
-      public let index: Int
-      public let startOffset: Double
-      public let duration: Double
-      public let title: String?
-      public let updatedAt: Date?
-      public let metadata: Metadata?
-      public let format: String?
-      public let bitRate: Int?
-      public let codec: String?
-      public let channels: Int?
-      public let channelLayout: String?
-      public let mimeType: String?
-      public let ino: String?
-
-      public struct Metadata: Codable, Sendable {
-        public let filename: String?
-        public let ext: String?
-        public let size: Int64?
-      }
-    }
   }
 
   public struct CollapsedSeries: Codable, Sendable {

--- a/API/Sources/API/Models/PlaySession.swift
+++ b/API/Sources/API/Models/PlaySession.swift
@@ -8,7 +8,7 @@ public struct PlaySession: Sendable {
   public let mediaType: String?
   public let currentTime: Double
   public let duration: Double
-  public let audioTracks: [Book.Media.Track]?
+  public let audioTracks: [AudioTrack]?
   public let chapters: [Book.Media.Chapter]?
   public let libraryItem: LibraryItem
 
@@ -18,7 +18,7 @@ public struct PlaySession: Sendable {
   }
 
   public struct StreamingTrack {
-    public var track: Book.Media.Track
+    public var track: AudioTrack
     public var url: URL
   }
 }
@@ -38,7 +38,7 @@ extension PlaySession: Codable {
     mediaType = try container.decodeIfPresent(String.self, forKey: .mediaType)
     currentTime = try container.decode(Double.self, forKey: .currentTime)
     duration = try container.decode(Double.self, forKey: .duration)
-    audioTracks = try container.decodeIfPresent([Book.Media.Track].self, forKey: .audioTracks)
+    audioTracks = try container.decodeIfPresent([AudioTrack].self, forKey: .audioTracks)
     chapters = try container.decodeIfPresent([Book.Media.Chapter].self, forKey: .chapters)
 
     if mediaType == "podcast" {

--- a/API/Sources/API/Models/PodcastEpisode.swift
+++ b/API/Sources/API/Models/PodcastEpisode.swift
@@ -11,23 +11,12 @@ public struct PodcastEpisode: Codable, Sendable {
   public let duration: Double?
   public let size: Int64?
   public let chapters: [Chapter]?
-  public let audioTrack: Track?
+  public let audioTrack: AudioTrack?
 
   public struct Chapter: Codable, Sendable {
     public let id: Int
     public let start: Double
     public let end: Double
     public let title: String
-  }
-
-  public struct Track: Codable, Sendable {
-    public let ino: String
-    public let metadata: Metadata?
-
-    public struct Metadata: Codable, Sendable {
-      public let filename: String?
-      public let ext: String?
-      public let size: Int64?
-    }
   }
 }

--- a/AudioBooth/AudioBooth/Services/DownloadManager.swift
+++ b/AudioBooth/AudioBooth/Services/DownloadManager.swift
@@ -389,18 +389,10 @@ private final class DownloadOperation: Operation, @unchecked Sendable {
     let trackCount = book.tracks?.count ?? 0
     AppLogger.download.info("Downloading audiobook: \(trackCount) tracks, \(totalBytes.formattedByteSize)")
 
-    try await downloadTracks()
-
-    guard let serverID = Audiobookshelf.shared.authentication.server?.id else {
-      throw URLError(.userAuthenticationRequired)
-    }
+    let tracks = try await downloadTracks()
 
     let localBook = LocalBook(from: book)
-    for track in localBook.tracks {
-      guard let ext = track.ext else { continue }
-      let resolvedExt = Self.correctExtension(mimeType: track.mimeType, codec: track.codec) ?? ext
-      track.relativePath = URL(string: "\(serverID)/audiobooks/\(bookID)/\(track.index)\(resolvedExt)")
-    }
+    localBook.tracks = tracks
     try? localBook.save()
   }
 
@@ -487,10 +479,9 @@ private final class DownloadOperation: Operation, @unchecked Sendable {
     resourceValues.isExcludedFromBackup = true
     try? episodesDirectory.setResourceValues(resourceValues)
 
-    let ext = audioTrack.metadata?.ext ?? ".mp3"
-    let resolvedExt = Self.correctExtension(mimeType: audioTrack.mimeType, codec: audioTrack.codec) ?? ext
+    let ext = audioTrack.sanitizedExt
     let trackURL = serverURL.appendingPathComponent("api/items/\(podcastID)/file/\(audioTrack.ino)/download")
-    let trackFile = episodeDirectory.appendingPathComponent("0\(resolvedExt)")
+    let trackFile = episodeDirectory.appendingPathComponent("0\(ext)")
 
     var request = URLRequest(url: trackURL)
     request.setValue(credentials.bearer, forHTTPHeaderField: "Authorization")
@@ -540,9 +531,9 @@ private final class DownloadOperation: Operation, @unchecked Sendable {
         startOffset: 0,
         duration: apiEpisode.duration ?? 0,
         filename: audioTrack.metadata?.filename,
-        ext: resolvedExt,
+        ext: ext,
         size: fileSize,
-        relativePath: URL(string: "\(serverID)/episodes/\(podcastID)/\(episodeID)/0\(resolvedExt)")
+        relativePath: URL(string: "\(serverID)/episodes/\(podcastID)/\(episodeID)/0\(ext)")
       ),
       chapters: (apiEpisode.chapters ?? []).map {
         Chapter(id: $0.id, start: $0.start, end: $0.end, title: $0.title)
@@ -551,7 +542,7 @@ private final class DownloadOperation: Operation, @unchecked Sendable {
     try? localEpisode.save()
   }
 
-  private func downloadTracks() async throws {
+  private func downloadTracks() async throws -> [Track] {
     guard let apiBook else { throw URLError(.unknown) }
 
     let apiTracks = apiBook.tracks ?? []
@@ -592,21 +583,15 @@ private final class DownloadOperation: Operation, @unchecked Sendable {
     resourceValues.isExcludedFromBackup = true
     try? audiobooksDirectory.setResourceValues(resourceValues)
 
+    var tracks: [Track] = []
+
     for apiTrack in apiTracks {
       guard !isCancelled else { throw CancellationError() }
 
-      guard
-        let ext = apiTrack.metadata?.ext,
-        let ino = apiTrack.ino
-      else {
-        AppLogger.download.error("Invalid track metadata for track \(apiTrack.index)")
-        throw URLError(.badURL)
-      }
+      let ext = apiTrack.sanitizedExt
+      let trackURL = serverURL.appendingPathComponent("api/items/\(bookID)/file/\(apiTrack.ino)/download")
 
-      let resolvedExt = Self.correctExtension(mimeType: apiTrack.mimeType, codec: apiTrack.codec) ?? ext
-      let trackURL = serverURL.appendingPathComponent("api/items/\(bookID)/file/\(ino)/download")
-
-      let trackFile = bookDirectory.appendingPathComponent("\(apiTrack.index)\(resolvedExt)")
+      let trackFile = bookDirectory.appendingPathComponent("\(apiTrack.index)\(ext)")
 
       var request = URLRequest(url: trackURL)
 
@@ -627,7 +612,14 @@ private final class DownloadOperation: Operation, @unchecked Sendable {
       if let size = apiTrack.metadata?.size {
         bytesDownloadedSoFar += size
       }
+
+      let relativePath = URL(string: "\(serverID)/audiobooks/\(bookID)/\(apiTrack.index)\(ext)")
+      let track = Track(from: apiTrack)
+      track.relativePath = relativePath
+      tracks.append(track)
     }
+
+    return tracks
   }
 
   private func downloadEbook(from ebookURL: URL, ext: String) async throws {
@@ -777,30 +769,6 @@ private final class DownloadOperation: Operation, @unchecked Sendable {
     continuation?.resume()
   }
 
-  static func correctExtension(mimeType: String?, codec: String?) -> String? {
-    if let mimeType {
-      switch mimeType.lowercased() {
-      case "audio/mpeg": return ".mp3"
-      case "audio/mp4": return ".m4a"
-      case "audio/ogg": return ".ogg"
-      case "audio/flac": return ".flac"
-      case "audio/aac": return ".aac"
-      case "audio/x-aiff": return ".aiff"
-      case "audio/webm": return ".webm"
-      default: break
-      }
-    }
-    if let codec {
-      switch codec.lowercased() {
-      case "mp3": return ".mp3"
-      case "aac": return ".m4a"
-      case "opus", "vorbis": return ".ogg"
-      case "flac": return ".flac"
-      default: break
-      }
-    }
-    return nil
-  }
 }
 
 extension DownloadOperation: URLSessionDownloadDelegate {
@@ -861,5 +829,35 @@ extension DownloadOperation: URLSessionDownloadDelegate {
       DownloadManager.shared.backgroundCompletionHandler = nil
       completionHandler()
     }
+  }
+}
+
+extension AudioTrack {
+  var sanitizedExt: String {
+    switch mimeType?.lowercased() {
+    case "audio/mpeg": return ".mp3"
+    case "audio/mp4", "audio/x-m4a": return ".m4a"
+    case "audio/ogg": return ".ogg"
+    case "audio/flac": return ".flac"
+    case "audio/aac": return ".aac"
+    case "audio/x-aiff": return ".aiff"
+    case "audio/webm": return ".webm"
+    case "audio/wav", "audio/x-wav": return ".wav"
+    case "audio/x-caf": return ".caf"
+    case "audio/opus": return ".opus"
+    default: break
+    }
+
+    switch codec?.lowercased() {
+    case "mp3": return ".mp3"
+    case "aac", "alac": return ".m4a"
+    case "opus": return ".opus"
+    case "vorbis": return ".ogg"
+    case "flac": return ".flac"
+    case let codec where codec?.hasPrefix("pcm") == true: return ".wav"
+    default: break
+    }
+
+    return metadata?.ext ?? ".mp3"
   }
 }

--- a/AudioBooth/AudioBooth/Services/WatchConnectivityManager.swift
+++ b/AudioBooth/AudioBooth/Services/WatchConnectivityManager.swift
@@ -343,7 +343,7 @@ extension WatchConnectivityManager: WCSessionDelegate {
 
       let book: Book
       let sessionID: String?
-      let audioTracks: [Book.Media.Track]
+      let audioTracks: [AudioTrack]
 
       if forDownload {
         book = try await Audiobookshelf.shared.books.fetch(id: bookID)
@@ -366,8 +366,8 @@ extension WatchConnectivityManager: WCSessionDelegate {
 
       let tracks: [[String: Any]] = audioTracks.map { audioTrack in
         let trackURL: String
-        if forDownload, let ino = audioTrack.ino {
-          var url = serverURL.appendingPathComponent("api/items/\(bookID)/file/\(ino)/download")
+        if forDownload {
+          var url = serverURL.appendingPathComponent("api/items/\(bookID)/file/\(audioTrack.ino)/download")
           switch token {
           case .legacy(let tokenValue):
             url.append(queryItems: [URLQueryItem(name: "token", value: tokenValue)])

--- a/Models/Sources/Models/Track.swift
+++ b/Models/Sources/Models/Track.swift
@@ -44,7 +44,7 @@ public final class Track {
     self.relativePath = nil
   }
 
-  public init(from track: Book.Media.Track) {
+  public init(from track: AudioTrack) {
     self.index = track.index
     self.startOffset = track.startOffset
     self.duration = track.duration


### PR DESCRIPTION
fix audio files failing to play when the actual codec doesn't match the file extension (e.g. an ogg file named `.mp3`), which caused repeated  "reconnecting..." toasts
for downloaded files, create a temporary symlink with the correct extension derived from the track's actual mimetype/codec so avplayer uses the right decoder
for streaming, force transcode on first recovery attempt instead of retrying direct play which fails identically

only tested on iphone