### PR TITLE
Auto-start timer when tapping end of chapter

### DIFF
--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheet.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheet.swift
@@ -160,7 +160,10 @@ struct TimerPickerSheet: View {
     }()
 
     HStack {
-      Button(action: { model.onChaptersChanged(chapterCount, autoStart: true) }) {
+      Button(action: {
+        model.onChaptersChanged(chapterCount)
+        model.onStartTimerTapped()
+      }) {
         VStack(alignment: .leading, spacing: 2) {
           Text(chapterCount == 1 ? "End of chapter" : "End of \(chapterCount) chapters")
             .font(.system(size: 16, weight: .medium))
@@ -274,7 +277,7 @@ extension TimerPickerSheet {
     init() {}
 
     func onQuickTimerSelected(_ minutes: Int) {}
-    func onChaptersChanged(_ value: Int, autoStart: Bool = false) {}
+    func onChaptersChanged(_ value: Int) {}
     func onOffSelected() {}
     func onStartTimerTapped() {}
   }

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheet.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheet.swift
@@ -160,7 +160,7 @@ struct TimerPickerSheet: View {
     }()
 
     HStack {
-      Button(action: { model.onChaptersChanged(1) }) {
+      Button(action: { model.onChaptersChanged(chapterCount, autoStart: true) }) {
         VStack(alignment: .leading, spacing: 2) {
           Text(chapterCount == 1 ? "End of chapter" : "End of \(chapterCount) chapters")
             .font(.system(size: 16, weight: .medium))
@@ -274,7 +274,7 @@ extension TimerPickerSheet {
     init() {}
 
     func onQuickTimerSelected(_ minutes: Int) {}
-    func onChaptersChanged(_ value: Int) {}
+    func onChaptersChanged(_ value: Int, autoStart: Bool = false) {}
     func onOffSelected() {}
     func onStartTimerTapped() {}
   }

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheetModel.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheetModel.swift
@@ -110,12 +110,9 @@ final class TimerPickerSheetViewModel: TimerPickerSheet.Model {
     onStartTimerTapped()
   }
 
-  override func onChaptersChanged(_ value: Int, autoStart: Bool = false) {
+  override func onChaptersChanged(_ value: Int) {
     selected = .chapters(value)
     updateEstimatedEndTime(for: value)
-    if autoStart {
-      onStartTimerTapped()
-    }
   }
 
   private func updateEstimatedEndTime(for chapterCount: Int) {

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheetModel.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheetModel.swift
@@ -110,9 +110,12 @@ final class TimerPickerSheetViewModel: TimerPickerSheet.Model {
     onStartTimerTapped()
   }
 
-  override func onChaptersChanged(_ value: Int) {
+  override func onChaptersChanged(_ value: Int, autoStart: Bool = false) {
     selected = .chapters(value)
     updateEstimatedEndTime(for: value)
+    if autoStart {
+      onStartTimerTapped()
+    }
   }
 
   private func updateEstimatedEndTime(for chapterCount: Int) {


### PR DESCRIPTION
- Closes https://github.com/AudioBooth/AudioBooth/issues/210

All the preset timer buttons (15 min, 30 min, etc.) auto-start the timer when tapped, but "End of chapter" required a separate tap on the Start button. Since I use "End of chapter" the most, it was really annoying to have to click 2 buttons to start end of chapter timers.

I added an `autoStart` param to `onChaptersChanged` so tapping the main row starts the timer immediately (same flow as `onQuickTimerSelected`), but the +/- steppers still just adjust the count. If you bump the stepper to 3 chapters then tap the row, it honors that value instead of resetting to 1.

https://github.com/user-attachments/assets/8c49720c-c04e-4bfe-9ce4-f9116d0872a4