### PR TITLE
Fix: Fixing transition and switcher on Library and Collections pages …

### DIFF
--- a/AudioBooth/AudioBooth/Screens/Collections/CollectionsRootPage.swift
+++ b/AudioBooth/AudioBooth/Screens/Collections/CollectionsRootPage.swift
@@ -51,14 +51,20 @@ private struct CollectionsRootContent: View {
   @StateObject private var playlists = CollectionsPageModel(mode: .playlists)
 
   var body: some View {
-    switch selected {
-    case .series:
-      SeriesPage(model: series)
-    case .collections:
-      CollectionsPage(model: collections)
-    case .playlists:
-      CollectionsPage(model: playlists)
+    ZStack {
+      switch selected {
+      case .series:
+        SeriesPage(model: series)
+          .transition(.opacity)
+      case .collections:
+        CollectionsPage(model: collections)
+          .transition(.opacity)
+      case .playlists:
+        CollectionsPage(model: playlists)
+          .transition(.opacity)
+      }
     }
+    .animation(.easeInOut(duration: 0.2), value: selected)
   }
 }
 

--- a/AudioBooth/AudioBooth/Screens/Library/LibraryRootPage.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/LibraryRootPage.swift
@@ -51,14 +51,20 @@ private struct LibraryRootContent: View {
   @StateObject private var narrators = NarratorsPageModel()
 
   var body: some View {
-    switch selected {
-    case .library:
-      LibraryPage(model: library)
-    case .authors:
-      AuthorsPage(model: authors)
-    case .narrators:
-      NarratorsPage(model: narrators)
+    ZStack {
+      switch selected {
+      case .library:
+        LibraryPage(model: library)
+          .transition(.opacity)
+      case .authors:
+        AuthorsPage(model: authors)
+          .transition(.opacity)
+      case .narrators:
+        NarratorsPage(model: narrators)
+          .transition(.opacity)
+      }
     }
+    .animation(.easeInOut(duration: 0.2), value: selected)
   }
 }
 


### PR DESCRIPTION

Main branch:
https://github.com/user-attachments/assets/e387b08e-32f8-4a40-ba92-816653fe4ad8



Updated recording:
https://github.com/user-attachments/assets/97f82bb4-848a-466a-8f09-d9d0a2669635


**UI Improvements:**

* `AudioBooth/Screens/Library/LibraryRootPage.swift` and `AudioBooth/Screens/Collections/CollectionsRootPage.swift`: Wrapped the main content in a `ZStack` and applied `.opacity` transitions to each page, with a smooth `.easeInOut` animation when switching between sections, resulting in improved visual transitions in both the Library and Collections screens. [[1]](diffhunk://#diff-b4dad2e28543d83713823f8b872b7b1fee464845fff4487d259ef3e3601f6409R54-R68) [[2]](diffhunk://#diff-3c8b5a7ec12725b0d2d8368d17ff79a2806dfc02fb9a1b159b1bccdd185fc186R54-R68)