### PR TITLE
Refresh the access token on 401 instead of forcing a re-login after a server outage

### DIFF
--- a/API/Sources/API/Audiobookshelf.swift
+++ b/API/Sources/API/Audiobookshelf.swift
@@ -61,8 +61,13 @@ public final class Audiobookshelf: @unchecked Sendable {
         let server = self.authentication.server
       else { return [:] }
 
-      let freshToken = try? await server.freshToken
-      guard let credentials = freshToken else { return [:] }
+      // Prefer a freshly refreshed token. If a proactive refresh can't run (e.g.
+      // the server is unreachable), fall back to the stored token so the request
+      // is still authenticated. A recovered server then answers 401, which
+      // NetworkService recovers from by refreshing and retrying — instead of
+      // receiving an unauthenticated request and reporting an authentication
+      // error for what is really a connection issue.
+      let credentials = (try? await server.freshToken) ?? server.token
 
       var headers = server.customHeaders
       headers["Authorization"] = credentials.bearer

--- a/API/Sources/API/CredentialsActor.swift
+++ b/API/Sources/API/CredentialsActor.swift
@@ -44,23 +44,51 @@ actor CredentialsActor {
         )
       }
 
-      let task = Task<Credentials, Error> { @MainActor [server] in
-        try await Audiobookshelf.shared.authentication.refreshToken(for: server)
-      }
+      return try await performRefresh(for: server)
+    }
+  }
 
-      refreshTask = task
+  /// Forces a refresh of the access token using the stored refresh token,
+  /// ignoring both the expiry check and the connection-error backoff.
+  ///
+  /// This is the recovery path for a 401 on a request we believed was
+  /// authenticated: the rejection proves the server is reachable, so the
+  /// backoff that was set while it was unreachable no longer applies.
+  /// Concurrent callers coalesce onto a single in-flight refresh so the
+  /// rotating refresh token is only exchanged once.
+  func forceRefresh() async throws -> Credentials {
+    if let refreshTask {
+      return try await refreshTask.value
+    }
 
-      do {
-        let credentials = try await task.value
-        refreshTask = nil
-        consecutiveFailures = 0
-        nextRetryAt = nil
-        return credentials
-      } catch {
-        refreshTask = nil
-        await handleError(error)
-        throw error
-      }
+    guard let server, case .bearer(_, let refreshToken, _) = server.token,
+      !refreshToken.isEmpty
+    else {
+      throw Audiobookshelf.AudiobookshelfError.networkError(
+        "Refresh token is no longer valid, re-authentication required"
+      )
+    }
+
+    return try await performRefresh(for: server)
+  }
+
+  private func performRefresh(for server: Server) async throws -> Credentials {
+    let task = Task<Credentials, Error> { @MainActor [server] in
+      try await Audiobookshelf.shared.authentication.refreshToken(for: server)
+    }
+
+    refreshTask = task
+
+    do {
+      let credentials = try await task.value
+      refreshTask = nil
+      consecutiveFailures = 0
+      nextRetryAt = nil
+      return credentials
+    } catch {
+      refreshTask = nil
+      await handleError(error)
+      throw error
     }
   }
 

--- a/API/Sources/API/Models/Server.swift
+++ b/API/Sources/API/Models/Server.swift
@@ -42,6 +42,23 @@ public final class Server: @unchecked Sendable {
     }
   }
 
+  /// Whether a 401 response can potentially be recovered by refreshing the
+  /// access token. Only bearer tokens with a non-empty refresh token are
+  /// refreshable; API keys and legacy tokens are not.
+  public var canAttemptRefresh: Bool {
+    if case .bearer(_, let refreshToken, _) = token {
+      return !refreshToken.isEmpty
+    }
+    return false
+  }
+
+  /// Forces a refresh of the access token using the stored refresh token,
+  /// bypassing the normal expiry check and connection backoff. Used to recover
+  /// from a 401 on a request that should have been authenticated.
+  public func forceTokenRefresh() async throws {
+    _ = try await credentialsActor.forceRefresh()
+  }
+
   public let storage: UserDefaults
 
   @ObservationIgnored @Stored("username") public var username: String? = nil

--- a/API/Sources/API/NetworkService.swift
+++ b/API/Sources/API/NetworkService.swift
@@ -174,7 +174,10 @@ final class NetworkService {
     }
   }
 
-  private func performRequest<T: Decodable>(_ request: NetworkRequest<T>) async throws -> NetworkResponse<T> {
+  private func performRequest<T: Decodable>(
+    _ request: NetworkRequest<T>,
+    allowAuthRetry: Bool = true
+  ) async throws -> NetworkResponse<T> {
     let urlRequest = try await buildURLRequest(from: request)
 
     AppLogger.network.info(
@@ -197,6 +200,27 @@ final class NetworkService {
         AppLogger.network.error(
           "HTTP \(httpResponse.statusCode) error. Response body: \(responseBody)"
         )
+
+        if httpResponse.statusCode == 401, allowAuthRetry, let server, server.canAttemptRefresh {
+          AppLogger.network.info("Received 401, refreshing access token and retrying once")
+          do {
+            try await server.forceTokenRefresh()
+          } catch {
+            // The refresh itself failed. Only a definitive rejection of the
+            // refresh token (401/403) means re-authentication is required; any
+            // other failure is a connection problem, so we keep the session and
+            // avoid forcing the user to log in again over a transient error.
+            if case NetworkError.httpError(let refreshStatus, _) = error,
+              refreshStatus == 401 || refreshStatus == 403
+            {
+              server.status = .authenticationError
+            } else {
+              server.status = .connectionError
+            }
+            throw NetworkError.httpError(statusCode: httpResponse.statusCode, message: responseBody)
+          }
+          return try await performRequest(request, allowAuthRetry: false)
+        }
 
         if httpResponse.statusCode == 401 {
           server?.status = .authenticationError

--- a/API/Sources/API/Services/AuthenticationService.swift
+++ b/API/Sources/API/Services/AuthenticationService.swift
@@ -198,8 +198,7 @@ public final class AuthenticationService: ObservableObject {
     let request = NetworkRequest<Authorize>(path: "/api/authorize", method: .post, body: nil)
 
     let altService = NetworkService(baseURL: url, server: server) {
-      let freshToken = try? await server.freshToken
-      guard let credentials = freshToken else { return [:] }
+      let credentials = (try? await server.freshToken) ?? server.token
       var headers = server.customHeaders
       headers["Authorization"] = credentials.bearer
       return headers

--- a/AudioBooth/AudioBooth/AudioBoothApp.swift
+++ b/AudioBooth/AudioBooth/AudioBoothApp.swift
@@ -43,6 +43,15 @@ struct AudioBoothApp: App {
       case .active:
         guard Audiobookshelf.shared.authentication.isAuthenticated else { return }
         SessionManager.shared.syncUnsyncedSessions()
+        // Re-probe the server when returning to the foreground if we aren't
+        // currently connected, so a server that recovered while the app was
+        // backgrounded reconnects on its own (using the refresh token) instead
+        // of waiting for the user to trigger a request manually.
+        if let server = Audiobookshelf.shared.authentication.server,
+          server.status != .connected
+        {
+          Task { await Audiobookshelf.shared.authentication.checkServersHealth() }
+        }
       default:
         break
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Automatic reconnection - the app now silently refreshes the access token using the stored refresh token and reconnects after the server has been unreachable, instead of requiring a full username and password re-login when the server comes back online
+
 ## [1.10.0]
 
 ### Added


### PR DESCRIPTION
## Summary

Fixes #276.

After the Audiobookshelf server is unreachable for longer than the access-token lifetime (access tokens expire after **~1 hour** by default; refresh tokens last 30 days), AudioBooth would drop into an **authentication-error** state and require a full **username/password re-login** when the server came back — instead of silently refreshing the access token with the stored refresh token and reconnecting, the way the official client does.

This PR makes the client recover the way the server's JWT model intends: refresh on a rejected request, retry once, and only ask for credentials when the refresh token itself is genuinely rejected.

## Root cause

Four independent gaps combined to turn a routine token expiry into a forced logout:

1. **No refresh-on-401.** `NetworkService` treated any HTTP 401 as terminal and set `.authenticationError` immediately — token refresh only ever happened *proactively* (by expiry), never *reactively* on a rejected request.
2. **Unauthenticated requests.** When a proactive refresh couldn't run (e.g. the server was unreachable), the auth-header provider returned **no** `Authorization` header. Against a *recovered* server that yields a 401, which was then misread as bad credentials.
3. **Aggressive recovery.** A single 401/403 (including one provoked by gaps 1–2) flipped the server to `.authenticationError`, whose only UI affordance is a full re-login — the valid refresh token was never used.
4. **No reconnect.** The only automatic probes were at cold launch and on a Wi-Fi/cellular interface change (for `.connectionError` only); a server that recovered on the same network was never re-probed.

## What this changes

- **`NetworkService`** — on a 401 for a refreshable connection, refresh the token once and retry the request a single time. Only a *definitive* refresh-token rejection (401/403 from `/auth/refresh`) becomes `.authenticationError`; any other failure is treated as `.connectionError`, so a transient hiccup never forces a re-login. (Bounded to one retry via an `allowAuthRetry` flag — no recursion.)
- **`Audiobookshelf` / `AuthenticationService.verifyAlternativeURL`** — when a proactive refresh can't run, fall back to the stored token instead of sending an unauthenticated request, so a recovered server returns a *recoverable* 401 rather than a misclassified auth failure.
- **`CredentialsActor`** — add a forced refresh that bypasses the expiry check and connection backoff (a 401 proves the server is reachable, so the connection backoff no longer applies). Concurrent 401s **coalesce onto a single in-flight refresh**, so the rotating refresh token is exchanged only once (avoids the rotation race in advplyr/audiobookshelf#5253).
- **`AudioBoothApp`** — when returning to the foreground and not currently connected, re-probe the server (`checkServersHealth()`) so a server that recovered while backgrounded reconnects without user action.
- **`CHANGELOG.md`** — note under `[Unreleased]`.

## Behavior after the fix

- **Outage shorter or longer than the token lifetime, server back, app interacts:** the stored refresh token mints a new access token and the connection recovers silently (green). No re-login.
- **Open the app while the server is still down (e.g. 12h):** requests fail with network errors, so the server shows a **connection** problem (orange), never an **authentication** problem (red); the refresh token is preserved; it reconnects automatically once the server returns.
- **Re-login is still required only** when a reachable server definitively rejects the refresh token (genuinely expired after 30 days, or revoked/logged-out server-side).

## Testing & confidence — please read

In the interest of transparency: **this change was developed from static source analysis and has not been run end-to-end on a device or simulator.**

Verified:
- **The full app compiles cleanly, natively.** `xcodebuild` reports `** BUILD SUCCEEDED **` for the `AudioBooth` scheme on the **iOS 26.5 Simulator with the embedded watchOS 26.5 Watch app** (iOS app + Watch app + widget extensions). All changed files compiled for both the iOS and watchOS architectures — **zero errors, zero warnings**. (Also confirmed independently via a Mac Catalyst build and a standalone `swift build` of the `API` package.)
- `swift-format` passes on all changed files.

Not verified:
- No live run, so the runtime refresh/reconnect behavior has not been observed end-to-end — that needs an Audiobookshelf server that can be taken offline past the access-token lifetime (~1h) and brought back.

Confidence is high because the change is the standard "refresh interceptor" pattern, is surgical (~85 lines, no change to the happy path), preserves existing behavior for API-key/legacy tokens (correctly excluded from the refresh-retry), and was reasoned through the key scenarios above. A maintainer confirming a real expiry → recovery cycle on a device would be a valuable final check before merge.

Not included (kept out of scope intentionally): any user-facing "connection lost" toast/notification, and aggressive background polling while the app stays foregrounded during an outage (recovery there happens on the next request or on foreground).
