### PR TITLE
Derive Watch widget bundle identifier from ORG_IDENTIFIER

### DIFF
--- a/AudioBooth/AudioBooth.xcodeproj/project.pbxproj
+++ b/AudioBooth/AudioBooth.xcodeproj/project.pbxproj
@@ -662,7 +662,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MARKETING_VERSION = 1.11;
-				PRODUCT_BUNDLE_IDENTIFIER = me.jgrenier.AudioBS.watchkitapp.AudioBoothWatchWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(ORG_IDENTIFIER).AudioBS.watchkitapp.AudioBoothWatchWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -695,7 +695,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MARKETING_VERSION = 1.11;
-				PRODUCT_BUNDLE_IDENTIFIER = me.jgrenier.AudioBS.watchkitapp.AudioBoothWatchWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(ORG_IDENTIFIER).AudioBS.watchkitapp.AudioBoothWatchWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
## Summary

Fixes a contributor build break: the `AudioBoothWatchWidget` extension hardcodes its bundle identifier instead of deriving it from `$(ORG_IDENTIFIER)`, so any contributor who follows [CONTRIBUTING.md](CONTRIBUTING.md) and sets their own `ORG_IDENTIFIER` in `Local.xcconfig` can't build the app for a device/simulator.

## The problem

In `project.pbxproj`, the watch widget's `PRODUCT_BUNDLE_IDENTIFIER` was hardcoded (Debug + Release):

```
me.jgrenier.AudioBS.watchkitapp.AudioBoothWatchWidget
```

while every sibling target derives from the config variable — `$(ORG_IDENTIFIER).AudioBS`, `$(ORG_IDENTIFIER).AudioBS.watchkitapp`, `$(ORG_IDENTIFIER).AudioBS.widget`. With a contributor's own org id, the parent Watch app becomes `<org>.AudioBS.watchkitapp` but the embedded widget stays on `me.jgrenier…`, so embedded-binary validation fails:

```
error: Embedded binary's bundle identifier is not prefixed with the parent app's bundle identifier.
    Embedded Binary Bundle Identifier:  me.jgrenier.AudioBS.watchkitapp.AudioBoothWatchWidget
    Parent App Bundle Identifier:       <org>.AudioBS.watchkitapp
```

## The fix

Both occurrences now use the variable, matching the other targets:

```
PRODUCT_BUNDLE_IDENTIFIER = "$(ORG_IDENTIFIER).AudioBS.watchkitapp.AudioBoothWatchWidget";
```

Two lines changed; this is the only hardcoded `me.jgrenier` bundle identifier in the project file.

## Verification

With a non-default `ORG_IDENTIFIER = com.example` in `Local.xcconfig`, a full build of the `AudioBooth` scheme (iOS app + embedded watchOS Watch app + widgets) now succeeds — the `ValidateEmbeddedBinary` step that previously failed now passes:

```
xcodebuild build -project AudioBooth/AudioBooth.xcodeproj -scheme AudioBooth \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -configuration Debug CODE_SIGNING_ALLOWED=NO -skipMacroValidation
** BUILD SUCCEEDED **
```

Confirmed both ways: the same build **fails** on `main` with a non-default org id and **succeeds** with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
