### PR TITLE
Focus search field when opening the search tab

### DIFF
--- a/AudioBooth/AudioBooth/Screens/Search/SearchView.swift
+++ b/AudioBooth/AudioBooth/Screens/Search/SearchView.swift
@@ -2,14 +2,22 @@ import API
 import Combine
 import SwiftUI
 
+@available(iOS 26.0, *)
 struct SearchPage: View {
   @StateObject var model: SearchView.Model
+  @FocusState private var searchFieldFocused: Bool
 
   var body: some View {
     NavigationStack {
       SearchView(model: model)
         .searchable(text: $model.searchText)
+        .searchFocused($searchFieldFocused)
         .navigationDestination(for: NavigationDestination.self) { $0.resolvedView }
+        .onAppear {
+          if model.searchText.isEmpty {
+            searchFieldFocused = true
+          }
+        }
     }
   }
 }

--- a/AudioBooth/AudioBooth/Screens/Search/SearchView.swift
+++ b/AudioBooth/AudioBooth/Screens/Search/SearchView.swift
@@ -5,17 +5,17 @@ import SwiftUI
 @available(iOS 26.0, *)
 struct SearchPage: View {
   @StateObject var model: SearchView.Model
-  @FocusState private var searchFieldFocused: Bool
+  @FocusState private var fieldFocused: Bool
 
   var body: some View {
     NavigationStack {
       SearchView(model: model)
         .searchable(text: $model.searchText)
-        .searchFocused($searchFieldFocused)
+        .searchFocused($fieldFocused)
         .navigationDestination(for: NavigationDestination.self) { $0.resolvedView }
         .onAppear {
           if model.searchText.isEmpty {
-            searchFieldFocused = true
+            fieldFocused = true
           }
         }
     }


### PR DESCRIPTION
Opening the search tab dropped you on the results view with the field unfocused, so searching was always tab, tap the field, then type. I wanted to kill that extra tap.

I focus the field on appear when there's no query yet, so switching to the tab puts the cursor straight in the search box. I guard on empty text so coming back to the tab with an existing search doesn't steal focus or pop the keyboard.


https://github.com/user-attachments/assets/665b3f6f-81aa-4a54-be5e-8a99194aa8d6