### PR TITLE
Add continue-listening fallback to auto-play next

### DIFF
--- a/AudioBooth/AudioBooth/Services/SmartContinueResolver.swift
+++ b/AudioBooth/AudioBooth/Services/SmartContinueResolver.swift
@@ -27,6 +27,9 @@ struct SmartContinueResolver {
       if let next = await resolveNextBookInSeries(currentBookID: currentItemID) {
         return next
       }
+      if let next = resolveNextBookInContinueListening(currentBookID: currentItemID) {
+        return next
+      }
       return resolveNextOfflineBook(currentBookID: currentItemID)
     }
   }
@@ -111,6 +114,28 @@ extension SmartContinueResolver {
     guard nextIndex < page.results.endIndex else { return nil }
 
     let next = page.results[nextIndex]
+    return ResolvedItem(
+      bookID: next.id,
+      title: next.title,
+      details: next.authorName,
+      coverURL: next.coverURL(),
+      podcastID: nil
+    )
+  }
+
+  private func resolveNextBookInContinueListening(currentBookID: String) -> ResolvedItem? {
+    guard
+      let personalized = audiobookshelf.libraries.getCachedPersonalized(),
+      let section = personalized.sections.first(where: { $0.id == "continue-listening" }),
+      case .books(let items) = section.entities
+    else { return nil }
+
+    guard
+      let next = items.first(where: {
+        $0.id != currentBookID && MediaProgress.progress(for: $0.id) < 1.0
+      })
+    else { return nil }
+
     return ResolvedItem(
       bookID: next.id,
       title: next.title,


### PR DESCRIPTION
Auto-play next went straight from next-in-series to the next downloaded book, so finishing a standalone book (or last book in a series) jumped to whatever happened to be next in downloads instead of what I was actually working through which is a bit jarring. I wanted it to reach for continue-listening before falling back to the download order since I usually listen to multiple books in parallel depending on my mood, so the next most recent listen is what I would expect to be picked up. The auto play next behavior becomes:
1. next in series
2. next in continue listening
3. next in downloads
