### PR TITLE
Add playback keyboard shortcuts for Mac

### DIFF
--- a/AudioBooth/AudioBooth/AudioBoothApp.swift
+++ b/AudioBooth/AudioBooth/AudioBoothApp.swift
@@ -61,6 +61,11 @@ struct AudioBoothApp: App {
         }
       }
     }
+    #if targetEnvironment(macCatalyst)
+    .commands {
+      PlaybackCommands()
+    }
+    #endif
   }
 
   private func syncAccentColorToWidget(_ color: Color?) {

--- a/AudioBooth/AudioBooth/Commands/PlaybackCommands.swift
+++ b/AudioBooth/AudioBooth/Commands/PlaybackCommands.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// Menu « Lecture » exposé dans la barre de menus du build Mac (Catalyst).
+///
+/// Réplique les actions déjà câblées par `MPRemoteCommandCenter`
+/// (`PlayerManager.setupRemoteCommandCenter()`) en déléguant à
+/// `PlayerManager.shared.current`, sans dupliquer de logique de lecture.
+struct PlaybackCommands: Commands {
+  @ObservedObject private var playerManager = PlayerManager.shared
+
+  private var current: BookPlayer.Model? {
+    playerManager.current
+  }
+
+  private var hasChapters: Bool {
+    !(current?.chapters?.chapters.isEmpty ?? true)
+  }
+
+  var body: some Commands {
+    CommandMenu("Lecture") {
+      Button(playerManager.isPlaying ? "Pause" : "Lecture") {
+        current?.onTogglePlaybackTapped()
+      }
+      .keyboardShortcut("p", modifiers: .command)
+      .disabled(current == nil)
+
+      Divider()
+
+      Button("Avancer") {
+        current?.onSkipForwardTapped(seconds: UserPreferences.shared.skipForwardInterval)
+      }
+      .keyboardShortcut(.rightArrow, modifiers: .command)
+      .disabled(current == nil)
+
+      Button("Reculer") {
+        current?.onSkipBackwardTapped(seconds: UserPreferences.shared.skipBackwardInterval)
+      }
+      .keyboardShortcut(.leftArrow, modifiers: .command)
+      .disabled(current == nil)
+
+      Divider()
+
+      Button("Chapitre suivant") {
+        current?.chapters?.onNextChapterTapped()
+      }
+      .keyboardShortcut(.rightArrow, modifiers: [.command, .shift])
+      .disabled(!hasChapters)
+
+      Button("Chapitre précédent") {
+        current?.chapters?.onPreviousChapterTapped()
+      }
+      .keyboardShortcut(.leftArrow, modifiers: [.command, .shift])
+      .disabled(!hasChapters)
+
+      Divider()
+
+      Button("Accélérer") {
+        current?.speed.onIncrease()
+      }
+      .keyboardShortcut("]", modifiers: .command)
+      .disabled(current == nil)
+
+      Button("Ralentir") {
+        current?.speed.onDecrease()
+      }
+      .keyboardShortcut("[", modifiers: .command)
+      .disabled(current == nil)
+    }
+  }
+}

--- a/AudioBooth/AudioBooth/Commands/PlaybackCommands.swift
+++ b/AudioBooth/AudioBooth/Commands/PlaybackCommands.swift
@@ -65,6 +65,20 @@ struct PlaybackCommands: Commands {
       }
       .keyboardShortcut("[", modifiers: .command)
       .disabled(current == nil)
+
+      Divider()
+
+      Button("Augmenter le volume") {
+        current?.volume.onIncrease()
+      }
+      .keyboardShortcut(.upArrow, modifiers: .command)
+      .disabled(current == nil)
+
+      Button("Baisser le volume") {
+        current?.volume.onDecrease()
+      }
+      .keyboardShortcut(.downArrow, modifiers: .command)
+      .disabled(current == nil)
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds playback keyboard shortcuts for the **Mac (Mac Catalyst)** build through a new **"Playback"** menu in the menu bar. No new playback logic: each command delegates to `PlayerManager.shared.current`, reusing the same entry points as the existing `MPRemoteCommandCenter` handlers.

## Shortcuts

| Shortcut | Action |
|----------|--------|
| ⌘P | Play / Pause (dynamic label) |
| ⌘→ / ⌘← | Skip forward / backward (uses preference intervals) |
| ⌘⇧→ / ⌘⇧← | Next / previous chapter |
| ⌘] / ⌘[ | Speed up / down (step 0.05, range 0.5–3.5) |
| ⌘↑ / ⌘↓ | Volume up / down (step 0.05, range 0.1–3.0) |

Items are disabled when no book is playing; chapter items are disabled for books without chapters.

## Implementation

- New `AudioBooth/AudioBooth/Commands/PlaybackCommands.swift` — a `struct PlaybackCommands: Commands` that observes `PlayerManager.shared` (dynamic labels + enable/disable state).
- `AudioBoothApp.swift` — `.commands { PlaybackCommands() }` on the `WindowGroup`, gated with `#if targetEnvironment(macCatalyst)` so the menu only appears on the Mac build.
- Reuses: `onTogglePlaybackTapped()`, `onSkipForwardTapped(seconds:)` / `onSkipBackwardTapped(seconds:)`, `chapters?.onNextChapterTapped()` / `onPreviousChapterTapped()`, `speed.onIncrease()/onDecrease()`, `volume.onIncrease()/onDecrease()`.

## Testing

- `swift-format lint --strict` passes on the changed files.
- Mac Catalyst build succeeds.
- Manually tested on Mac: every shortcut works, Play/Pause label updates dynamically, items disabled when no book is playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
