### PR TITLE
Improve VoiceOver accessibility: labels, mini-player grouping, Catalyst server menu

### DIFF
--- a/AudioBooth/AudioBooth/Screens/BookPlayer/MiniBookPlayer.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/MiniBookPlayer.swift
@@ -37,25 +37,35 @@ struct MiniBookPlayer: View, Equatable {
   @ViewBuilder
   var content: some View {
     HStack {
-      cover
+      HStack {
+        cover
 
-      VStack(alignment: .leading, spacing: 2) {
-        Text(player.title)
-          .font(.footnote)
-          .fontWeight(.medium)
-          .foregroundColor(.primary)
-          .lineLimit(1)
-          .frame(maxWidth: .infinity, alignment: .leading)
+        VStack(alignment: .leading, spacing: 2) {
+          Text(player.title)
+            .font(.footnote)
+            .fontWeight(.medium)
+            .foregroundColor(.primary)
+            .lineLimit(1)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-        Text(player.playbackProgress.totalTimeRemaining.formattedTimeRemaining)
-          .font(.caption)
-          .foregroundColor(.secondary)
-          .fontWeight(.medium)
-          .accessibilityLabel(player.playbackProgress.totalTimeRemaining.accessibilityTimeRemaining)
+          Text(player.playbackProgress.totalTimeRemaining.formattedTimeRemaining)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .fontWeight(.medium)
+            .accessibilityLabel(player.playbackProgress.totalTimeRemaining.accessibilityTimeRemaining)
+        }
+      }
+      .accessibilityElement(children: .combine)
+      .accessibilityAddTraits(.isButton)
+      .accessibilityHint("Opens the player")
+      .accessibilityAction {
+        playerManager.showFullPlayer()
       }
 
       buttons
     }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Player")
   }
 
   private var cover: some View {
@@ -88,6 +98,7 @@ struct MiniBookPlayer: View, Equatable {
         }
         .disabled(player.isLoading)
         .buttonStyle(.borderless)
+        .accessibilityLabel(player.isPlaying ? "Pause" : "Play")
 
         Button {
           player.isQueuePresented = true
@@ -97,6 +108,7 @@ struct MiniBookPlayer: View, Equatable {
             .foregroundColor(.secondary)
         }
         .buttonStyle(.borderless)
+        .accessibilityLabel("Playback queue")
       }
     }
   }
@@ -127,20 +139,28 @@ struct LegacyMiniBookPlayer: View {
   @ViewBuilder
   var content: some View {
     HStack {
-      cover
+      HStack {
+        cover
 
-      VStack(alignment: .leading, spacing: 2) {
-        Text(player.title)
-          .font(.footnote)
-          .fontWeight(.medium)
-          .foregroundColor(.primary)
-          .lineLimit(1)
+        VStack(alignment: .leading, spacing: 2) {
+          Text(player.title)
+            .font(.footnote)
+            .fontWeight(.medium)
+            .foregroundColor(.primary)
+            .lineLimit(1)
 
-        Text(player.playbackProgress.totalTimeRemaining.formattedTimeRemaining)
-          .font(.caption)
-          .foregroundColor(.secondary)
-          .fontWeight(.medium)
-          .accessibilityLabel(player.playbackProgress.totalTimeRemaining.accessibilityTimeRemaining)
+          Text(player.playbackProgress.totalTimeRemaining.formattedTimeRemaining)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .fontWeight(.medium)
+            .accessibilityLabel(player.playbackProgress.totalTimeRemaining.accessibilityTimeRemaining)
+        }
+      }
+      .accessibilityElement(children: .combine)
+      .accessibilityAddTraits(.isButton)
+      .accessibilityHint("Opens the player")
+      .accessibilityAction {
+        playerManager.showFullPlayer()
       }
 
       Spacer()
@@ -168,6 +188,7 @@ struct LegacyMiniBookPlayer: View {
         }
         .disabled(player.isLoading)
         .buttonStyle(.borderless)
+        .accessibilityLabel(player.isPlaying ? "Pause" : "Play")
 
         Button {
           player.isQueuePresented = true
@@ -177,8 +198,11 @@ struct LegacyMiniBookPlayer: View {
             .foregroundColor(.secondary)
         }
         .buttonStyle(.borderless)
+        .accessibilityLabel("Playback queue")
       }
     }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Player")
   }
 
   private var cover: some View {

--- a/AudioBooth/AudioBooth/Screens/Collections/Collection/CollectionDetailPage/CollectionDetailPage.swift
+++ b/AudioBooth/AudioBooth/Screens/Collections/Collection/CollectionDetailPage/CollectionDetailPage.swift
@@ -297,6 +297,7 @@ struct CollectionDetailPage: View {
           .foregroundStyle(Color.accentColor)
       }
       .buttonStyle(.plain)
+      .accessibilityLabel("Play")
     }
     .contentShape(Rectangle())
     .overlay {

--- a/AudioBooth/AudioBooth/Screens/EbookReader/EbookChapterPickerSheet.swift
+++ b/AudioBooth/AudioBooth/Screens/EbookReader/EbookChapterPickerSheet.swift
@@ -68,6 +68,8 @@ struct EbookChapterPickerSheet: View {
               Image(systemName: model.showSubchapters ? "list.bullet.indent" : "list.bullet")
             }
             .tint(.primary)
+            .accessibilityLabel("Show subchapters")
+            .accessibilityValue(model.showSubchapters ? Text("On") : Text("Off"))
           }
         }
         ToolbarItem(placement: .topBarTrailing) {

--- a/AudioBooth/AudioBooth/Screens/Home/HomePage.swift
+++ b/AudioBooth/AudioBooth/Screens/Home/HomePage.swift
@@ -2,6 +2,7 @@ import API
 import Combine
 import SwiftData
 import SwiftUI
+import UIKit
 
 struct HomePage: View {
   @Environment(\.appTheme) var theme
@@ -91,6 +92,10 @@ struct HomePage: View {
             .tint(.primary)
             .frame(width: 44, height: 44)
             .glassEffect()
+            .accessibilityLabel("Daily listening goal")
+            .accessibilityValue(
+              Text("\(Int(dailyGoal.current / 60)) of \(dailyGoal.goal) minutes")
+            )
           }
           .sharedBackgroundVisibility(.hidden)
         }
@@ -103,6 +108,7 @@ struct HomePage: View {
           Image(systemName: "gear")
         }
         .tint(.primary)
+        .accessibilityLabel("Settings")
       }
     }
     .sheet(isPresented: $showingSettings) {
@@ -321,76 +327,205 @@ extension HomePage {
     }
   }
 
+  private var serverMenuAccessibilityLabel: String {
+    let name = libraries.current?.name ?? String(localized: "Server")
+    let status = String(localized: connectionStatusLabel)
+    return String(localized: "Server: \(name), \(status)")
+  }
+
   var serverMenuToolbarItem: some ToolbarContent {
     ToolbarItem(placement: .topBarLeading) {
-      Menu {
-        if authentication.isAuthenticated {
-          ForEach(model.availableLibraries) { library in
-            if library.id == libraries.current?.id {
-              Button {
-                model.onLibrarySelected(library.id)
-              } label: {
-                Label(library.name, systemImage: "checkmark")
-              }
-            } else {
-              Button {
-                model.onLibrarySelected(library.id)
-              } label: {
-                Text(library.name)
-              }
+      // SwiftUI's `Menu` inside a toolbar item is not activatable by VoiceOver on
+      // Mac Catalyst (the menu never opens). A UIKit pull-down button behaves
+      // identically on screen but is fully accessible, so use it there and keep
+      // the native SwiftUI menu everywhere else.
+      #if targetEnvironment(macCatalyst)
+      ServerMenuButton(
+        title: libraries.current?.name ?? String(localized: "Server"),
+        accessibilityLabel: serverMenuAccessibilityLabel,
+        isAuthenticated: authentication.isAuthenticated,
+        libraries: model.availableLibraries,
+        currentLibraryID: libraries.current?.id,
+        hasAlternativeURL: authentication.server?.alternativeURL != nil,
+        isUsingAlternativeURL: authentication.server?.isUsingAlternativeURL ?? false,
+        onSelectLibrary: { model.onLibrarySelected($0) },
+        onToggleAlternativeURL: { model.onToggleAlternativeURL() },
+        onServerDetails: { showingServerDetails = true },
+        onManageServers: { showingServerList = true }
+      )
+      #else
+      serverMenu
+      #endif
+    }
+  }
+
+  #if !targetEnvironment(macCatalyst)
+  private var serverMenu: some View {
+    Menu {
+      if authentication.isAuthenticated {
+        ForEach(model.availableLibraries) { library in
+          if library.id == libraries.current?.id {
+            Button {
+              model.onLibrarySelected(library.id)
+            } label: {
+              Label(library.name, systemImage: "checkmark")
+            }
+          } else {
+            Button {
+              model.onLibrarySelected(library.id)
+            } label: {
+              Text(library.name)
             }
           }
+        }
 
-          if let server = authentication.server, server.alternativeURL != nil {
-            ControlGroup("Server URL") {
-              Button("Primary", systemImage: server.isUsingAlternativeURL ? "circle" : "checkmark.circle.fill") {
-                if server.isUsingAlternativeURL {
-                  model.onToggleAlternativeURL()
-                }
+        if let server = authentication.server, server.alternativeURL != nil {
+          ControlGroup("Server URL") {
+            Button("Primary", systemImage: server.isUsingAlternativeURL ? "circle" : "checkmark.circle.fill") {
+              if server.isUsingAlternativeURL {
+                model.onToggleAlternativeURL()
               }
-              .tint(server.isUsingAlternativeURL ? nil : .accentColor)
-
-              Button("Alternative", systemImage: server.isUsingAlternativeURL ? "checkmark.circle.fill" : "circle") {
-                if !server.isUsingAlternativeURL {
-                  model.onToggleAlternativeURL()
-                }
-              }
-              .tint(server.isUsingAlternativeURL ? .accentColor : nil)
             }
-          }
+            .tint(server.isUsingAlternativeURL ? nil : .accentColor)
 
-          if !model.availableLibraries.isEmpty {
-            Divider()
+            Button("Alternative", systemImage: server.isUsingAlternativeURL ? "checkmark.circle.fill" : "circle") {
+              if !server.isUsingAlternativeURL {
+                model.onToggleAlternativeURL()
+              }
+            }
+            .tint(server.isUsingAlternativeURL ? .accentColor : nil)
           }
+        }
 
-          Button {
-            showingServerDetails = true
-          } label: {
-            Label("Server Details", systemImage: "info.circle")
-          }
+        if !model.availableLibraries.isEmpty {
+          Divider()
         }
 
         Button {
-          showingServerList = true
+          showingServerDetails = true
         } label: {
-          Label("Manage Servers", systemImage: "server.rack")
+          Label("Server Details", systemImage: "info.circle")
         }
-      } label: {
-        HStack(spacing: 4) {
-          #if !targetEnvironment(macCatalyst)
-          Text(verbatim: "●")
-            .foregroundStyle(connectionStatusColor)
-          #endif
-          Text(libraries.current?.name ?? "Server")
-            .bold()
-        }
-        .frame(maxWidth: 250)
       }
-      .accessibilityLabel("Server: \(libraries.current?.name ?? "Server"), \(connectionStatusLabel)")
-      .tint(.primary)
+
+      Button {
+        showingServerList = true
+      } label: {
+        Label("Manage Servers", systemImage: "server.rack")
+      }
+    } label: {
+      HStack(spacing: 4) {
+        Text(verbatim: "●")
+          .foregroundStyle(connectionStatusColor)
+        Text(libraries.current?.name ?? "Server")
+          .bold()
+      }
+      .frame(maxWidth: 250)
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(serverMenuAccessibilityLabel)
     }
+    .tint(.primary)
+  }
+  #endif
+}
+
+#if targetEnvironment(macCatalyst)
+/// UIKit-backed pull-down button used in place of SwiftUI's `Menu` on Mac Catalyst,
+/// where a toolbar `Menu` cannot be opened with VoiceOver. Renders identically but is
+/// fully accessible because UIKit pull-down buttons expose a real activation action.
+private struct ServerMenuButton: UIViewRepresentable {
+  let title: String
+  let accessibilityLabel: String
+  let isAuthenticated: Bool
+  let libraries: [HomePage.Model.LibraryItem]
+  let currentLibraryID: String?
+  let hasAlternativeURL: Bool
+  let isUsingAlternativeURL: Bool
+  let onSelectLibrary: (String) -> Void
+  let onToggleAlternativeURL: () -> Void
+  let onServerDetails: () -> Void
+  let onManageServers: () -> Void
+
+  func makeUIView(context: Context) -> UIButton {
+    let button = UIButton(type: .system)
+    button.showsMenuAsPrimaryAction = true
+    button.changesSelectionAsPrimaryAction = false
+    button.tintColor = .label
+    button.contentHorizontalAlignment = .leading
+    button.titleLabel?.font = UIFontMetrics(forTextStyle: .body)
+      .scaledFont(for: .systemFont(ofSize: 17, weight: .bold))
+    button.titleLabel?.adjustsFontForContentSizeCategory = true
+    button.titleLabel?.lineBreakMode = .byTruncatingTail
+    button.widthAnchor.constraint(lessThanOrEqualToConstant: 250).isActive = true
+    return button
+  }
+
+  func updateUIView(_ button: UIButton, context: Context) {
+    button.setTitle(title, for: .normal)
+    button.accessibilityLabel = accessibilityLabel
+    button.menu = makeMenu()
+  }
+
+  private func makeMenu() -> UIMenu {
+    var sections: [UIMenuElement] = []
+
+    if isAuthenticated {
+      let libraryActions = libraries.map { library in
+        let action = UIAction(title: library.name) { _ in
+          onSelectLibrary(library.id)
+        }
+        action.state = library.id == currentLibraryID ? .on : .off
+        return action
+      }
+      if !libraryActions.isEmpty {
+        sections.append(UIMenu(title: "", options: .displayInline, children: libraryActions))
+      }
+
+      if hasAlternativeURL {
+        let primary = UIAction(title: String(localized: "Primary")) { _ in
+          if isUsingAlternativeURL {
+            onToggleAlternativeURL()
+          }
+        }
+        primary.state = isUsingAlternativeURL ? .off : .on
+
+        let alternative = UIAction(title: String(localized: "Alternative")) { _ in
+          if !isUsingAlternativeURL {
+            onToggleAlternativeURL()
+          }
+        }
+        alternative.state = isUsingAlternativeURL ? .on : .off
+
+        sections.append(
+          UIMenu(
+            title: String(localized: "Server URL"),
+            options: .displayInline,
+            children: [primary, alternative]
+          )
+        )
+      }
+
+      let details = UIAction(
+        title: String(localized: "Server Details"),
+        image: UIImage(systemName: "info.circle")
+      ) { _ in
+        onServerDetails()
+      }
+      sections.append(UIMenu(title: "", options: .displayInline, children: [details]))
+    }
+
+    let manage = UIAction(
+      title: String(localized: "Manage Servers"),
+      image: UIImage(systemName: "server.rack")
+    ) { _ in
+      onManageServers()
+    }
+    sections.append(UIMenu(title: "", options: .displayInline, children: [manage]))
+
+    return UIMenu(title: "", children: sections)
   }
 }
+#endif
 
 extension HomePage {
   @Observable

--- a/AudioBooth/AudioBooth/Screens/PodcastDetails/PodcastEpisodeDetailView.swift
+++ b/AudioBooth/AudioBooth/Screens/PodcastDetails/PodcastEpisodeDetailView.swift
@@ -123,6 +123,19 @@ struct PodcastEpisodeDetailView: View {
       .font(.title3)
     }
     .buttonStyle(.plain)
+    .accessibilityLabel("Download")
+    .accessibilityValue(downloadStateLabel)
+  }
+
+  private var downloadStateLabel: Text {
+    switch model.downloadState {
+    case .notDownloaded:
+      return Text("Not downloaded")
+    case .downloading:
+      return Text("Downloading")
+    case .downloaded:
+      return Text("Downloaded")
+    }
   }
 
   private var toggleFinishedButton: some View {
@@ -132,6 +145,8 @@ struct PodcastEpisodeDetailView: View {
         .foregroundStyle(model.isCompleted ? .green : .secondary)
     }
     .buttonStyle(.plain)
+    .accessibilityLabel("Mark as finished")
+    .accessibilityAddTraits(model.isCompleted ? .isSelected : [])
   }
 
   private var addToPlaylistButton: some View {
@@ -141,6 +156,7 @@ struct PodcastEpisodeDetailView: View {
         .foregroundStyle(Color.accentColor)
     }
     .buttonStyle(.plain)
+    .accessibilityLabel("Add to playlist")
   }
 
   private var episodePlayButtonText: String {

--- a/AudioBooth/AudioBooth/Screens/Servers/Server/AlternativeURL/AlternativeURLView.swift
+++ b/AudioBooth/AudioBooth/Screens/Servers/Server/AlternativeURL/AlternativeURLView.swift
@@ -21,6 +21,7 @@ struct AlternativeURLView: View {
                 .foregroundStyle(.secondary)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Clear URL")
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes a set of VoiceOver accessibility gaps, with a focus on Mac Catalyst (where several controls were unreachable) while also improving iOS.

## Changes

- **Icon-only buttons** now have accessibility labels (and values/selected traits where they carry state): clear alternative URL, podcast episode download/finished/add-to-playlist, collection item play, ebook subchapters toggle, Home Settings button and daily-goal gauge.
- **Mini-player**: play/pause and queue buttons labeled; the cover+title zone is exposed as a button that opens the full player (previously only reachable via a tap gesture VoiceOver could not trigger); the whole mini-player is wrapped in a named "Player" accessibility container.
- **Server menu on Mac Catalyst**: a SwiftUI `Menu` inside a toolbar item cannot be opened with VoiceOver on Catalyst (the menu never appears, though the mouse works). The native `Menu` is kept on iOS; on Catalyst it is backed by a UIKit `UIButton` + `UIMenu` (`showsMenuAsPrimaryAction`) that renders identically but exposes a real activation action.

## Platform scope

- The UIKit menu replacement is **Mac Catalyst only** (`#if targetEnvironment(macCatalyst)`); iOS keeps the original SwiftUI `Menu` unchanged.
- The label and grouping changes apply to both platforms but are purely additive VoiceOver metadata — intended to have no visual or behavioral change for sighted users.

## Testing

- Builds for Mac Catalyst.
- Manually verified with VoiceOver on Mac Catalyst: labels are announced, the mini-player navigates as a group and opens the player, and the server menu now opens with VO+Space and all its entries work (library switch + checkmark, Server Details, Manage Servers).

## Note from the author

I'm blind and worked entirely through VoiceOver. I could confirm the accessibility behavior, but I couldn't visually verify that the appearance is unchanged. These changes are meant to be visually neutral (the Catalyst UIKit button aims to match the original menu button exactly, and the label/grouping changes only add accessibility metadata), but I'd appreciate a second pair of eyes on the visuals. Please feel free to reject or modify anything as you see fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)