### PR TITLE
Improve player VoiceOver: adjustable scrubber, accessible equalizer, Catalyst More menu

### DIFF
--- a/AudioBooth/AudioBooth/Screens/BookPlayer/BookPlayer.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/BookPlayer.swift
@@ -3,6 +3,7 @@ import AVKit
 import Combine
 import SwiftData
 import SwiftUI
+import UIKit
 
 struct BookPlayer: View {
   @ObservedObject var model: Model
@@ -12,6 +13,8 @@ struct BookPlayer: View {
   @Environment(\.verticalSizeClass) private var verticalSizeClass
   @ObservedObject private var playerManager = PlayerManager.shared
   @ObservedObject private var preferences = UserPreferences.shared
+
+  @State private var path = NavigationPath()
 
   private var supportedOrientations: UIInterfaceOrientationMask {
     switch preferences.playerOrientation {
@@ -25,7 +28,7 @@ struct BookPlayer: View {
   }
 
   var body: some View {
-    NavigationStack {
+    NavigationStack(path: $path) {
       ZStack {
         playerBackground
           .accessibilityHidden(true)
@@ -71,71 +74,18 @@ struct BookPlayer: View {
         }
 
         ToolbarItem(placement: .topBarTrailing) {
-          Menu {
-            if let podcastID = model.podcastID {
-              NavigationLink(value: NavigationDestination.podcast(id: podcastID)) {
-                Label("Podcast Details", systemImage: "mic")
-              }
-            } else {
-              NavigationLink(value: NavigationDestination.book(id: model.id)) {
-                Label("Book Details", systemImage: "book")
-              }
-            }
-
-            if Audiobookshelf.shared.authentication.server?.permissions?.download == true,
-              model.downloadState == .notDownloaded
-            {
-              Button(action: { model.onDownloadTapped() }) {
-                Label("Download", systemImage: "icloud.and.arrow.down")
-              }
-            }
-
-            let disabledControls = Set(PlayerControl.allCases).subtracting(preferences.playerControls)
-            if disabledControls.contains(.speed) {
-              Button(action: { model.speed.isPresented = true }) {
-                Label(PlayerControl.speed.displayName, systemImage: PlayerControl.speed.systemImage)
-              }
-            }
-            if disabledControls.contains(.timer) {
-              Button(action: { model.timer.isPresented = true }) {
-                Label(PlayerControl.timer.displayName, systemImage: PlayerControl.timer.systemImage)
-              }
-            }
-            if disabledControls.contains(.bookmarks), model.bookmarks != nil {
-              Button(action: { model.onBookmarksTapped() }) {
-                Label(PlayerControl.bookmarks.displayName, systemImage: PlayerControl.bookmarks.systemImage)
-              }
-            }
-            if disabledControls.contains(.history), model.history != nil {
-              Button(action: { model.onHistoryTapped() }) {
-                Label(PlayerControl.history.displayName, systemImage: PlayerControl.history.systemImage)
-              }
-            }
-            if disabledControls.contains(.volume) {
-              Button(action: { model.volume.isPresented = true }) {
-                Label(PlayerControl.volume.displayName, systemImage: PlayerControl.volume.systemImage)
-              }
-            }
-
-            if disabledControls.contains(.equalizer) {
-              Button(action: { model.equalizer.isPresented = true }) {
-                Label(PlayerControl.equalizer.displayName, systemImage: PlayerControl.equalizer.systemImage)
-              }
-            }
-
-            Button(action: { model.isQueuePresented = true }) {
-              Label("Queue", systemImage: "list.bullet")
-            }
-
-            Divider()
-
-            Button(action: { model.isSettingsPresented = true }) {
-              Label("Player Settings", systemImage: "gearshape")
-            }
-          } label: {
-            Label("More", systemImage: "ellipsis")
-          }
+          // A SwiftUI toolbar `Menu` cannot be opened with VoiceOver on Mac Catalyst,
+          // so back it with a UIKit pull-down there and keep the native menu on iOS.
+          #if targetEnvironment(macCatalyst)
+          UIKitMenuButton(
+            systemImage: "ellipsis",
+            accessibilityLabel: String(localized: "More"),
+            menu: moreUIMenu
+          )
           .tint(.primary)
+          #else
+          moreMenu
+          #endif
         }
       }
       .navigationDestination(for: NavigationDestination.self) { $0.resolvedView }
@@ -201,6 +151,177 @@ struct BookPlayer: View {
       }
     }
   }
+
+  #if !targetEnvironment(macCatalyst)
+  private var moreMenu: some View {
+    Menu {
+      if let podcastID = model.podcastID {
+        NavigationLink(value: NavigationDestination.podcast(id: podcastID)) {
+          Label("Podcast Details", systemImage: "mic")
+        }
+      } else {
+        NavigationLink(value: NavigationDestination.book(id: model.id)) {
+          Label("Book Details", systemImage: "book")
+        }
+      }
+
+      if Audiobookshelf.shared.authentication.server?.permissions?.download == true,
+        model.downloadState == .notDownloaded
+      {
+        Button(action: { model.onDownloadTapped() }) {
+          Label("Download", systemImage: "icloud.and.arrow.down")
+        }
+      }
+
+      let disabledControls = Set(PlayerControl.allCases).subtracting(preferences.playerControls)
+      if disabledControls.contains(.speed) {
+        Button(action: { model.speed.isPresented = true }) {
+          Label(PlayerControl.speed.displayName, systemImage: PlayerControl.speed.systemImage)
+        }
+      }
+      if disabledControls.contains(.timer) {
+        Button(action: { model.timer.isPresented = true }) {
+          Label(PlayerControl.timer.displayName, systemImage: PlayerControl.timer.systemImage)
+        }
+      }
+      if disabledControls.contains(.bookmarks), model.bookmarks != nil {
+        Button(action: { model.onBookmarksTapped() }) {
+          Label(PlayerControl.bookmarks.displayName, systemImage: PlayerControl.bookmarks.systemImage)
+        }
+      }
+      if disabledControls.contains(.history), model.history != nil {
+        Button(action: { model.onHistoryTapped() }) {
+          Label(PlayerControl.history.displayName, systemImage: PlayerControl.history.systemImage)
+        }
+      }
+      if disabledControls.contains(.volume) {
+        Button(action: { model.volume.isPresented = true }) {
+          Label(PlayerControl.volume.displayName, systemImage: PlayerControl.volume.systemImage)
+        }
+      }
+
+      if disabledControls.contains(.equalizer) {
+        Button(action: { model.equalizer.isPresented = true }) {
+          Label(PlayerControl.equalizer.displayName, systemImage: PlayerControl.equalizer.systemImage)
+        }
+      }
+
+      Button(action: { model.isQueuePresented = true }) {
+        Label("Queue", systemImage: "list.bullet")
+      }
+
+      Divider()
+
+      Button(action: { model.isSettingsPresented = true }) {
+        Label("Player Settings", systemImage: "gearshape")
+      }
+    } label: {
+      Label("More", systemImage: "ellipsis")
+    }
+    .tint(.primary)
+  }
+  #endif
+
+  #if targetEnvironment(macCatalyst)
+  private func moreUIMenu() -> UIMenu {
+    var items: [UIMenuElement] = []
+
+    if let podcastID = model.podcastID {
+      items.append(
+        UIAction(title: String(localized: "Podcast Details"), image: UIImage(systemName: "mic")) { _ in
+          path.append(NavigationDestination.podcast(id: podcastID))
+        }
+      )
+    } else {
+      items.append(
+        UIAction(title: String(localized: "Book Details"), image: UIImage(systemName: "book")) { _ in
+          path.append(NavigationDestination.book(id: model.id))
+        }
+      )
+    }
+
+    if Audiobookshelf.shared.authentication.server?.permissions?.download == true,
+      model.downloadState == .notDownloaded
+    {
+      items.append(
+        UIAction(
+          title: String(localized: "Download"),
+          image: UIImage(systemName: "icloud.and.arrow.down")
+        ) { _ in
+          model.onDownloadTapped()
+        }
+      )
+    }
+
+    let disabledControls = Set(PlayerControl.allCases).subtracting(preferences.playerControls)
+    if disabledControls.contains(.speed) {
+      items.append(playerControlAction(.speed) { model.speed.isPresented = true })
+    }
+    if disabledControls.contains(.timer) {
+      items.append(playerControlAction(.timer) { model.timer.isPresented = true })
+    }
+    if disabledControls.contains(.bookmarks), model.bookmarks != nil {
+      items.append(playerControlAction(.bookmarks) { model.onBookmarksTapped() })
+    }
+    if disabledControls.contains(.history), model.history != nil {
+      items.append(playerControlAction(.history) { model.onHistoryTapped() })
+    }
+    if disabledControls.contains(.volume) {
+      items.append(playerControlAction(.volume) { model.volume.isPresented = true })
+    }
+    if disabledControls.contains(.equalizer) {
+      items.append(playerControlAction(.equalizer) { model.equalizer.isPresented = true })
+    }
+
+    items.append(
+      UIAction(title: String(localized: "Queue"), image: UIImage(systemName: "list.bullet")) { _ in
+        model.isQueuePresented = true
+      }
+    )
+
+    let settings = UIAction(
+      title: String(localized: "Player Settings"),
+      image: UIImage(systemName: "gearshape")
+    ) { _ in
+      model.isSettingsPresented = true
+    }
+
+    return UIMenu(children: [
+      UIMenu(title: "", options: .displayInline, children: items),
+      UIMenu(title: "", options: .displayInline, children: [settings]),
+    ])
+  }
+
+  private func playerControlAction(_ control: PlayerControl, handler: @escaping () -> Void) -> UIAction {
+    UIAction(
+      title: String(localized: control.displayName),
+      image: UIImage(systemName: control.systemImage)
+    ) { _ in
+      handler()
+    }
+  }
+
+  private struct UIKitMenuButton: UIViewRepresentable {
+    let systemImage: String
+    let accessibilityLabel: String
+    let menu: () -> UIMenu
+
+    func makeUIView(context: Context) -> UIButton {
+      let button = UIButton(type: .system)
+      button.showsMenuAsPrimaryAction = true
+      button.tintColor = .label
+      button.setImage(UIImage(systemName: systemImage), for: .normal)
+      button.setContentHuggingPriority(.required, for: .horizontal)
+      return button
+    }
+
+    func updateUIView(_ button: UIButton, context: Context) {
+      button.setImage(UIImage(systemName: systemImage), for: .normal)
+      button.accessibilityLabel = accessibilityLabel
+      button.menu = menu()
+    }
+  }
+  #endif
 
   @ViewBuilder
   private var playerBackground: some View {

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/PlaybackProgress/PlaybackProgressView.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/PlaybackProgress/PlaybackProgressView.swift
@@ -73,6 +73,16 @@ struct PlaybackProgressView: View {
         )
       }
       .frame(height: 16)
+      .accessibilityRepresentation {
+        Slider(
+          value: seekBinding,
+          in: 0...max(1.0, model.current + model.remaining),
+          step: 15
+        ) {
+          Text("Playback position")
+        }
+        .accessibilityValue(Text(accessibilityPositionDescription))
+      }
 
       HStack {
         Text(formatCurrentTime(model.current))
@@ -106,6 +116,32 @@ struct PlaybackProgressView: View {
 
   private func formatCurrentTime(_ duration: TimeInterval) -> String {
     Duration.seconds(duration).formatted(.time(pattern: .hourMinuteSecond))
+  }
+
+  /// Drives the VoiceOver / keyboard `Slider` exposed via `accessibilityRepresentation`.
+  /// Seeks on every adjustment while keeping the visible bar in sync; the total
+  /// (current + remaining) stays constant during a seek, so the slider range is stable.
+  private var seekBinding: Binding<Double> {
+    Binding(
+      get: { model.current },
+      set: { newValue in
+        let total = model.current + model.remaining
+        guard total > 0 else { return }
+        let clamped = min(max(0, newValue), total)
+        model.progress = clamped / total
+        model.current = clamped
+        model.remaining = total - clamped
+        model.onProgressChanged(model.progress)
+      }
+    )
+  }
+
+  private var accessibilityPositionDescription: String {
+    let elapsed = Duration.seconds(model.current)
+      .formatted(.units(allowed: [.hours, .minutes, .seconds], width: .wide))
+    let total = Duration.seconds(model.current + model.remaining)
+      .formatted(.units(allowed: [.hours, .minutes, .seconds], width: .wide))
+    return String(localized: "\(elapsed) of \(total)")
   }
 
   private var supplementary: (progress: Double, elapsed: TimeInterval, remaining: TimeInterval)? {

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/EqualizerSheet.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/EqualizerSheet.swift
@@ -95,6 +95,7 @@ struct EqualizerSheet: View {
         Text(verbatim: "\(formattedGain(model.preamp)) dB")
           .font(.system(size: 13, weight: .medium).monospacedDigit())
           .foregroundColor(.primary)
+          .accessibilityHidden(true)
       }
 
       Slider(
@@ -118,6 +119,7 @@ struct EqualizerSheet: View {
             .font(.system(size: 10, weight: .medium).monospacedDigit())
             .foregroundColor(.primary)
             .frame(width: 32)
+            .accessibilityHidden(true)
 
           VerticalSlider(
             value: Binding(
@@ -132,6 +134,7 @@ struct EqualizerSheet: View {
           Text(model.bandLabels[index])
             .font(.system(size: 9, weight: .medium))
             .foregroundColor(.primary)
+            .accessibilityHidden(true)
         }
         .frame(maxWidth: .infinity)
       }

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/EqualizerSheet.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/EqualizerSheet.swift
@@ -39,7 +39,7 @@ struct EqualizerSheet: View {
     .opacity(model.isEnabled ? 1 : 0.5)
     .overlay(alignment: .topTrailing) {
       Toggle(
-        "",
+        "Equalizer",
         isOn: Binding(
           get: { model.isEnabled },
           set: { model.onToggleEnabled($0) }
@@ -78,6 +78,7 @@ struct EqualizerSheet: View {
       }
       .labelsHidden()
       .pickerStyle(.menu)
+      .accessibilityLabel("Volume Leveling")
     }
   }
 
@@ -104,6 +105,8 @@ struct EqualizerSheet: View {
         in: -12...12,
         step: 0.5
       )
+      .accessibilityLabel("Preamplifier")
+      .accessibilityValue(Text(verbatim: "\(formattedGain(model.preamp)) decibels"))
     }
   }
 
@@ -121,7 +124,8 @@ struct EqualizerSheet: View {
               get: { model.bandGains[index] },
               set: { model.onBandChanged(index, gain: $0) }
             ),
-            range: -12...12
+            range: -12...12,
+            accessibilityLabel: "\(model.bandLabels[index]) hertz"
           )
           .frame(height: 160)
 
@@ -177,6 +181,9 @@ struct EqualizerSheet: View {
 private struct VerticalSlider: View {
   @Binding var value: Float
   let range: ClosedRange<Float>
+  var step: Float = 0.5
+  var accessibilityLabel: String = ""
+
   var body: some View {
     GeometryReader { geo in
       let height = geo.size.height
@@ -213,6 +220,22 @@ private struct VerticalSlider: View {
           }
       )
     }
+    .accessibilityRepresentation {
+      Slider(
+        value: $value,
+        in: range,
+        step: step
+      ) {
+        Text(accessibilityLabel)
+      }
+      .accessibilityValue(Text(accessibilityValueText))
+    }
+  }
+
+  private var accessibilityValueText: String {
+    let rounded = (value * 2).rounded() / 2
+    let formatted = rounded == 0 ? "0" : String(format: "%+.1f", rounded)
+    return String(localized: "\(formatted) decibels")
   }
 }
 


### PR DESCRIPTION
## Summary

Makes the audio player's custom, gesture-only controls usable with VoiceOver (and Mac keyboard), and fixes the player's More menu on Mac Catalyst. Independent of #313 (no overlapping files); both are part of the same VoiceOver accessibility pass.

## Changes

- **Playback scrubber**: the seek bar is a custom `GeometryReader` + `DragGesture` with no accessibility, so VoiceOver and Full Keyboard Access couldn't reach it. Exposes a hidden `Slider` via `accessibilityRepresentation` bound to the same state — adjustable trait, VoiceOver swipe, and arrow-key seeking (15s steps), value announced as elapsed/total.
- **Equalizer**: the per-band `VerticalSlider` had the same gesture-only problem; each now exposes a `Slider` representation (labeled by frequency, value in decibels, 0.5 dB steps). Also labels the enable toggle, preamplifier slider and volume-leveling picker (previously empty labels), and hides the redundant per-band value/frequency texts from VoiceOver so only the sliders are announced.
- **Player "More" menu**: a SwiftUI toolbar `Menu` cannot be opened with VoiceOver on Mac Catalyst, which left the equalizer, sleep timer, book details, player settings, etc. unreachable. On Catalyst it is backed by a UIKit `UIButton` + `UIMenu` (`showsMenuAsPrimaryAction`); a `NavigationPath` drives the detail-screen pushes that were `NavigationLink`s. The native `Menu` is kept on iOS.

## Platform scope

- The UIKit More-menu replacement is **Mac Catalyst only** (`#if targetEnvironment(macCatalyst)`); iOS keeps the original SwiftUI `Menu`.
- The scrubber/equalizer `accessibilityRepresentation` changes apply to both platforms but are additive: `accessibilityRepresentation` provides a non-rendered `Slider` to assistive tech only, so there is no visual or behavioral change for sighted users.

## Testing

- Builds for Mac Catalyst.
- Manually verified with VoiceOver on Mac Catalyst: the scrubber and every equalizer band announce and adjust; the More menu opens with VO+Space and all entries work, including Book Details navigation.

## Note from the author

I'm blind and worked entirely through VoiceOver. I could confirm the accessibility behavior by ear, but I couldn't visually verify that the appearance is unchanged. These changes are meant to be visually neutral (`accessibilityRepresentation` and `accessibilityHidden` add no visible elements; the Catalyst UIKit button aims to match the original ellipsis menu), but I'd appreciate a second pair of eyes on the visuals. Please feel free to reject or modify anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)