### PR TITLE
fix: crash when opening Custom Headers while adding first server on iOS 18

### DIFF
--- a/AudioBooth/AudioBooth/Screens/Servers/Server/CustomHeaders/CustomHeadersView.swift
+++ b/AudioBooth/AudioBooth/Screens/Servers/Server/CustomHeaders/CustomHeadersView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct CustomHeadersView: View {
   @Environment(\.appTheme) var theme
 
-  @StateObject var model: Model
+  @Bindable var model: Model
 
   var body: some View {
     List {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tip jar for sponsors - Tip jar section now collapses when you have an active sponsor subscription
 
 ### Fixed
+- Custom headers - Fixed a crash when opening Custom Headers while adding the first server on iOS 18
 - Podcast playback - Various improvements and fixes around podcast playback and episode management (thanks @Creationsss)
 - Podcast library search - Fixed search failing in podcast libraries, now showing matching podcasts and episodes
 


### PR DESCRIPTION
## Summary

Opening Custom Headers while adding the first server crashes on iOS 18. `CustomHeadersView` declared the shared observable server model as `@StateObject`, but the model is `@Observable` (not an `ObservableObject`), and on iOS 18 SwiftUI traps when a not-yet-persisted model is wrapped that way from the add-server sheet. Declaring it `@Bindable` matches how the model is passed everywhere else and stops the crash.

Fixes #312
