### PR TITLE
Keep long-press menu actions near the cover

### DIFF
--- a/AudioBooth/AudioBooth/Screens/Home/ContinueListening/ContinueListeningCoverFlowView.swift
+++ b/AudioBooth/AudioBooth/Screens/Home/ContinueListening/ContinueListeningCoverFlowView.swift
@@ -104,6 +104,7 @@ struct ContinueListeningCoverFlowView: View {
         }
       }
     }
+    .menuOrder(.priority)
     .accessibilityLabel(accessibilityLabel(for: item))
     .bookCardAccessibilityActions(model: item)
     .onAppear(perform: item.onAppear)

--- a/AudioBooth/AudioBooth/Screens/Library/Library/BookCard/BookCard.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Library/BookCard/BookCard.swift
@@ -22,6 +22,7 @@ struct BookCard: View {
         PodcastEpisodeContextMenu(model: model)
       }
     }
+    .menuOrder(.priority)
     .bookCardAccessibilityActions(model: model)
     .sheet(
       item: Binding(
@@ -67,6 +68,7 @@ struct BookListCard: View {
           PodcastEpisodeContextMenu(model: model)
         }
       }
+      .menuOrder(.priority)
       .bookCardAccessibilityActions(model: model)
       .sheet(
         item: Binding(

--- a/AudioBooth/AudioBooth/Screens/PodcastDetails/PodcastDetailsView.swift
+++ b/AudioBooth/AudioBooth/Screens/PodcastDetails/PodcastDetailsView.swift
@@ -553,6 +553,7 @@ struct PodcastDetailsView: View {
               PodcastEpisodeContextMenu(model: contextMenu)
             }
           }
+          .menuOrder(.priority)
           .podcastEpisodeAccessibilityActions(
             episodeID: episode.id,
             menu: episode.contextMenu


### PR DESCRIPTION
Long-pressing a book or episode always pinned the primary actions (Play, Download) to the top of the menu, so when the menu opened above the cover they became the farthest thing to reach instead of the closest. Annoying on taller screens where cards near the bottom always open the menu upward.

I switched the long-press menus to priority ordering so the OS keeps the primary actions closest to your touch point and flips them when the menu opens upward.

| Before | After |
|--------|--------|
| <img width="286" height="639" alt="Screenshot 2026-07-13 at 4 54 58 PM" src="https://github.com/user-attachments/assets/75b245b2-241d-4486-ad68-6323505a4b49" /> | <img width="256" height="576" alt="Screenshot 2026-07-13 at 4 59 40 PM" src="https://github.com/user-attachments/assets/bd37e65d-38d4-4365-9529-b9f8f6b6880b" /> | 