### PR TITLE
Keep the currently playing download when marking as finished

### DIFF
--- a/AudioBooth/AudioBooth/Services/BookActionable.swift
+++ b/AudioBooth/AudioBooth/Services/BookActionable.swift
@@ -17,7 +17,13 @@ extension BookActionable {
     try await Audiobookshelf.shared.libraries.markAsFinished(bookID: bookID)
 
     if UserPreferences.shared.removeDownloadOnCompletion {
-      if DownloadManager.shared.downloadStates[bookID] == .downloaded {
+      // Deleting while this book is still loaded would leave the player pointing
+      // at files that no longer exist (e.g. re-listening right after finishing).
+      // Skip it here — removeCompleted() sweeps finished downloads on the next
+      // home fetch, once the book is no longer the current player.
+      if DownloadManager.shared.downloadStates[bookID] == .downloaded,
+        PlayerManager.shared.current?.id != bookID
+      {
         removeDownload()
       }
     }


### PR DESCRIPTION
Fixes #336.

## Summary

With "Remove Download on Completion" enabled, finishing a downloaded book deletes its files (and `LocalBook` record) **at the moment of completion, while the book is still loaded in the player**. Trying to re-listen right after the book ends (e.g. jumping back a couple of chapters) leaves the player rebuilding `AVPlayerItem`s from deleted file URLs — it silently gets stuck: no playback, no error, no recovery.

## Root cause

`markAsFinished()` (`BookActionable.swift`) calls `removeDownload()` → `DownloadManager.deleteDownload(for:)`, which removes the files and the `LocalBook` record unconditionally. The existing `PlayerManager.shared.current?.id != bookID` check inside `removeDownload()` only guards a second, redundant record deletion, so it doesn't protect the currently playing book.

Meanwhile the batch cleanup for the same preference — `DownloadManager.removeCompleted()`, run on every Home remote fetch — already skips the currently playing item. The completion path just bypassed that rule.

## Fix

Apply the same guard in the completion path: skip the immediate deletion when the finished book is still the current player.

Nothing is left behind — `removeCompleted()` deletes the finished download on the next Home fetch, once the book is no longer loaded. Deletion is deferred, not lost. Books finished while *not* loaded in the player (e.g. marked finished from the context menu) are unaffected and still delete immediately.

## Testing

Compile-verified (`xcodebuild`, iOS Simulator, `BUILD SUCCEEDED`) and `swift-format` clean. The root cause and fix were derived from source analysis of a reproducible user report (finish downloaded book → seek back → player stuck); **not** runtime-tested on a device. The change mirrors the guard `removeCompleted()` already uses, so the deferred-cleanup behavior is the codebase's existing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
