### PR TITLE
Filter out authors with zero books from Authors list

### DIFF
--- a/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorsPageModel.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Authors/AuthorsPageModel.swift
@@ -60,7 +60,9 @@ final class AuthorsPageModel: AuthorsPage.Model {
         return
       }
 
-      let authorCards = response.results.map { AuthorCardModel(author: $0) }
+      let authorCards = response.results
+        .map { AuthorCardModel(author: $0) }
+        .filter { $0.bookCount > 0 }
 
       allAuthors.append(contentsOf: authorCards)
       sections = buildSections(from: allAuthors)

--- a/AudioBooth/AudioBooth/Screens/Library/Narrators/NarratorsPageModel.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Narrators/NarratorsPageModel.swift
@@ -27,9 +27,10 @@ final class NarratorsPageModel: NarratorsPage.Model {
     do {
       let response = try await audiobookshelf.narrators.fetch()
 
-      let narratorCards = response.map { narrator in
-        NarratorCardModel(narrator: narrator)
-      }
+      let narratorCards =
+        response
+        .map { narrator in NarratorCardModel(narrator: narrator) }
+        .filter { $0.bookCount > 0 }
 
       self.narrators = narratorCards
     } catch {


### PR DESCRIPTION
Closes #328.

Authors with zero books (e.g. left behind after a metadata fix + re-import)
were still showing up in Library > Authors. `AuthorCard.Model` already
carries `bookCount` and the row view already hides the "N books" label when
it's 0 — the list just wasn't filtering them out. Filters `bookCount > 0`
before building the sections.

Only touched the Authors list, since the request only reported it there —
happy to add the same filter for Narrators if that turns out to need it too.
