### PR TITLE
Close the player when a finished book has nothing to play next

### DIFF
--- a/AudioBooth/AudioBooth/Services/PlayerManager.swift
+++ b/AudioBooth/AudioBooth/Services/PlayerManager.swift
@@ -566,7 +566,10 @@ extension PlayerManager {
     guard
       userPreferences.smartContinuePlayback,
       let currentID = current?.id
-    else { return }
+    else {
+      clearCurrent()
+      return
+    }
 
     let currentPodcastID = current?.podcastID
 


### PR DESCRIPTION
Part of #335 — fixes the "player stays open" half.

With Smart Continue off and an empty queue, `playNext()` (called from
`recordBookCompletionIfNeeded` on completion, and from the last-chapter case
of `onNextChapterTapped`) just returned when there was nothing to play next.
`clearCurrent()` already existed for this — it's used on failure paths — but
was never called here, so the finished book stayed loaded in the player
indefinitely. This calls it in that guard's `else` branch.

Scoped to just this part on purpose. The issue also reports Home's "Continue
Listening" staying stale until the next foreground/pull-to-refresh — that's
a separate, real gap (no completion → refresh signal today) but touches
`HomePageModel`'s refresh wiring, so I kept it out of this PR rather than
grow the diff. Happy to follow up with that one if useful.
