### PR TITLE
Pad series/genre/tag list content past the mini player

### DIFF
--- a/AudioBooth/AudioBooth/Screens/Library/Library/LibraryPage.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Library/LibraryPage.swift
@@ -5,7 +5,6 @@ import SwiftUI
 struct LibraryPage: View {
   @Environment(\.appTheme) var theme
   @ObservedObject private var preferences = UserPreferences.shared
-  @ObservedObject private var playerManager = PlayerManager.shared
 
   @ObservedObject var model: Model
 
@@ -276,10 +275,7 @@ struct LibraryPage: View {
         }
       }
       .padding(.horizontal)
-      // tabViewBottomAccessory's safe-area inset doesn't always reach pushed
-      // NavigationStack destinations reliably, so the last row can end up
-      // permanently hidden behind the mini player. Pad past it explicitly.
-      .padding(.bottom, playerManager.hasActivePlayer ? 80 : 0)
+      .padding(.bottom, 80)
       .environment(\.itemDisplayMode, preferences.libraryDisplayMode)
     }
   }

--- a/AudioBooth/AudioBooth/Screens/Library/Library/LibraryPage.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Library/LibraryPage.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct LibraryPage: View {
   @Environment(\.appTheme) var theme
   @ObservedObject private var preferences = UserPreferences.shared
+  @ObservedObject private var playerManager = PlayerManager.shared
 
   @ObservedObject var model: Model
 
@@ -275,6 +276,10 @@ struct LibraryPage: View {
         }
       }
       .padding(.horizontal)
+      // tabViewBottomAccessory's safe-area inset doesn't always reach pushed
+      // NavigationStack destinations reliably, so the last row can end up
+      // permanently hidden behind the mini player. Pad past it explicitly.
+      .padding(.bottom, playerManager.hasActivePlayer ? 80 : 0)
       .environment(\.itemDisplayMode, preferences.libraryDisplayMode)
     }
   }


### PR DESCRIPTION
Closes #305.

`LibraryPage` backs the series/genre/tag/narrator/author-library detail
lists (`NavigationDestination.resolvedView`), and its `ScrollView` had no
bottom padding of its own — it was relying entirely on
`tabViewBottomAccessory`'s automatic safe-area inset to keep content clear
of the mini player. That doesn't seem to reliably reach pushed
`NavigationStack` destinations (this shows up on iOS 26 with
`tabBarMinimizeBehavior(.onScrollDown)`), so with enough items the last row
ends up permanently behind the mini player with no way to scroll it clear.

This adds explicit bottom padding to the scroll content whenever a player is
active, as a buffer past whatever the system's own inset does or doesn't
account for.

**Caveat:** I don't have a library large enough to reproduce the original
report, so I couldn't visually confirm this on-device — this is based on
reading the layout code, not a confirmed repro. The 80pt figure is a rough
buffer, not measured against the actual mini-player height, so please treat
it as a starting point to adjust rather than a precise fix if you get a
chance to check it against a real device.
