### PR TITLE
Add a close button to adaptive sheets on Mac Catalyst

### DIFF
--- a/AudioBooth/AudioBooth/Extensions/View+AdaptiveSheet.swift
+++ b/AudioBooth/AudioBooth/Extensions/View+AdaptiveSheet.swift
@@ -41,30 +41,18 @@ struct AdaptiveSheetModifier<SheetContent: View>: ViewModifier {
             }
           )
           #if targetEnvironment(macCatalyst)
-        // Mac Catalyst has no swipe-to-dismiss gesture, and these sheets
-        // have no close button of their own, so without this the only way
-        // to dismiss one is the Escape key. Top-leading to match the
-        // NavigationStack sheets elsewhere in the app, whose
-        // .cancellationAction close button lands there (PlayerQueueView).
-        //
-        // An overlay rather than a real NavigationStack + toolbar: the
-        // toolbar route adds a navigation bar outside the height that
-        // presentationDetents below is measured from, so the sheet comes
-        // out too short and centers the overflowing content, clipping it
-        // at both ends. An overlay doesn't take part in layout, so the
-        // existing sizing keeps working untouched.
-        .overlay(alignment: .topLeading) {
-          Button(action: { isPresented = false }) {
-            Image(systemName: "xmark")
-            .font(.system(size: 12, weight: .bold))
-            .foregroundStyle(.secondary)
-            .frame(width: 28, height: 28)
-            .background(Color.primary.opacity(0.12), in: .circle)
-          }
-          .buttonStyle(.plain)
-          .accessibilityLabel("Close")
-          .padding()
-        }
+            .overlay(alignment: .topTrailing) {
+              Button(action: { isPresented = false }) {
+                Image(systemName: "xmark")
+                  .font(.system(size: 12, weight: .bold))
+                  .foregroundStyle(.secondary)
+                  .frame(width: 28, height: 28)
+                  .background(Color.primary.opacity(0.12), in: .circle)
+              }
+              .buttonStyle(.plain)
+              .accessibilityLabel("Close")
+              .padding()
+            }
           #endif
           .presentationDetents([.height(contentHeight)])
           .presentationDragIndicator(.visible)

--- a/AudioBooth/AudioBooth/Extensions/View+AdaptiveSheet.swift
+++ b/AudioBooth/AudioBooth/Extensions/View+AdaptiveSheet.swift
@@ -43,15 +43,26 @@ struct AdaptiveSheetModifier<SheetContent: View>: ViewModifier {
           #if targetEnvironment(macCatalyst)
         // Mac Catalyst has no swipe-to-dismiss gesture, and these sheets
         // have no close button of their own, so without this the only way
-        // to dismiss one is the Escape key. Matches the Label("Close",
-        // systemImage: "xmark") convention used everywhere else in the
-        // app; top-trailing is free on every adaptive sheet except
-        // EqualizerSheet, which moved its own top-trailing control to
-        // make room.
-        .overlay(alignment: .topTrailing) {
+        // to dismiss one is the Escape key. Top-leading to match the
+        // NavigationStack sheets elsewhere in the app, whose
+        // .cancellationAction close button lands there (PlayerQueueView).
+        //
+        // An overlay rather than a real NavigationStack + toolbar: the
+        // toolbar route adds a navigation bar outside the height that
+        // presentationDetents below is measured from, so the sheet comes
+        // out too short and centers the overflowing content, clipping it
+        // at both ends. An overlay doesn't take part in layout, so the
+        // existing sizing keeps working untouched.
+        .overlay(alignment: .topLeading) {
           Button(action: { isPresented = false }) {
-            Label("Close", systemImage: "xmark")
+            Image(systemName: "xmark")
+            .font(.system(size: 12, weight: .bold))
+            .foregroundStyle(.secondary)
+            .frame(width: 28, height: 28)
+            .background(Color.primary.opacity(0.12), in: .circle)
           }
+          .buttonStyle(.plain)
+          .accessibilityLabel("Close")
           .padding()
         }
           #endif

--- a/AudioBooth/AudioBooth/Extensions/View+AdaptiveSheet.swift
+++ b/AudioBooth/AudioBooth/Extensions/View+AdaptiveSheet.swift
@@ -40,6 +40,21 @@ struct AdaptiveSheetModifier<SheetContent: View>: ViewModifier {
                 }
             }
           )
+          #if targetEnvironment(macCatalyst)
+        // Mac Catalyst has no swipe-to-dismiss gesture, and these sheets
+        // have no close button of their own, so without this the only way
+        // to dismiss one is the Escape key. Matches the Label("Close",
+        // systemImage: "xmark") convention used everywhere else in the
+        // app; top-trailing is free on every adaptive sheet except
+        // EqualizerSheet, which moved its own top-trailing control to
+        // make room.
+        .overlay(alignment: .topTrailing) {
+          Button(action: { isPresented = false }) {
+            Label("Close", systemImage: "xmark")
+          }
+          .padding()
+        }
+          #endif
           .presentationDetents([.height(contentHeight)])
           .presentationDragIndicator(.visible)
       }

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/EqualizerSheet.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/EqualizerSheet.swift
@@ -37,7 +37,7 @@ struct EqualizerSheet: View {
         .disabled(!model.isEnabled)
     }
     .opacity(model.isEnabled ? 1 : 0.5)
-    .overlay(alignment: .topLeading) {
+    .overlay(alignment: .topTrailing) {
       Toggle(
         "",
         isOn: Binding(
@@ -46,6 +46,9 @@ struct EqualizerSheet: View {
         )
       )
       .labelsHidden()
+      // Mac Catalyst renders a plain Toggle as a checkbox; this keeps it a
+      // switch there, and is a no-op on iOS where switch is already default.
+      .toggleStyle(.switch)
       .padding()
     }
   }

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/EqualizerSheet.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/EqualizerSheet.swift
@@ -4,6 +4,12 @@ import SwiftUI
 struct EqualizerSheet: View {
   @ObservedObject var model: Model
 
+  #if targetEnvironment(macCatalyst)
+    private let enableToggleAlignment: Alignment = .topLeading
+  #else
+    private let enableToggleAlignment: Alignment = .topTrailing
+  #endif
+
   var body: some View {
     VStack(spacing: 0) {
       Text("Equalizer")
@@ -37,7 +43,7 @@ struct EqualizerSheet: View {
         .disabled(!model.isEnabled)
     }
     .opacity(model.isEnabled ? 1 : 0.5)
-    .overlay(alignment: .topTrailing) {
+    .overlay(alignment: enableToggleAlignment) {
       Toggle(
         "",
         isOn: Binding(
@@ -46,8 +52,6 @@ struct EqualizerSheet: View {
         )
       )
       .labelsHidden()
-      // Mac Catalyst renders a plain Toggle as a checkbox; this keeps it a
-      // switch there, and is a no-op on iOS where switch is already default.
       .toggleStyle(.switch)
       .padding()
     }

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/EqualizerSheet.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/EqualizerSheet.swift
@@ -37,7 +37,7 @@ struct EqualizerSheet: View {
         .disabled(!model.isEnabled)
     }
     .opacity(model.isEnabled ? 1 : 0.5)
-    .overlay(alignment: .topTrailing) {
+    .overlay(alignment: .topLeading) {
       Toggle(
         "",
         isOn: Binding(

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/FloatPickerSheet.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/FloatPickerSheet.swift
@@ -100,7 +100,7 @@ struct FloatPickerSheet: View {
       }
       .padding(.bottom, 40)
     }
-    .overlay(alignment: .topTrailing) {
+    .overlay(alignment: .topLeading) {
       Button(model.isEditing ? "Done" : "Edit") {
         model.onToggleEdit()
       }

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/FloatPickerSheet.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/FloatPickerSheet.swift
@@ -100,7 +100,7 @@ struct FloatPickerSheet: View {
       }
       .padding(.bottom, 40)
     }
-    .overlay(alignment: .topLeading) {
+    .overlay(alignment: .topTrailing) {
       Button(model.isEditing ? "Done" : "Edit") {
         model.onToggleEdit()
       }


### PR DESCRIPTION
Not tied to an existing issue — found this by using the Mac build directly.

**The problem:** on Mac Catalyst, several of the player's sheets (Equalizer,
Volume, Speed, Timer, the ebook reader's mini player sheet, and the pinned
playlist preferences sheet) are impossible to close except with Escape.
They all go through the shared `AdaptiveSheetModifier`
(`View+AdaptiveSheet.swift`), which gives them `presentationDragIndicator`
for swipe-to-dismiss — but Mac Catalyst has no swipe gesture, and unlike the
other sheets in the app (which use `NavigationStack` + a toolbar close
button, e.g. `PlayerQueueView`, `BookmarkViewerSheet`), none of these six
have a close button of their own. So on Mac there's no button, no titlebar
close control, nothing clickable — Escape is the only way out.

**The fix**, all `#if targetEnvironment(macCatalyst)` so iOS/iPadOS are
untouched and keep the drag indicator and swipe-to-dismiss exactly as before:

- `View+AdaptiveSheet.swift` — a close button overlaid top-leading, to match
  where the `.cancellationAction` close button lands on the app's
  NavigationStack sheets.
- `FloatPickerSheet.swift` (volume + speed) — its Edit/Done button was
  top-leading, where the close button now goes, so it moves to top-trailing.
  That ends up matching `PlayerQueueView` exactly: close left, edit right.
- `EqualizerSheet.swift` — `.toggleStyle(.switch)` on the enable toggle.
  Mac Catalyst renders a plain `Toggle` as a checkbox, which looked out of
  place for an on/off control; no-op on iOS, where switch is already the
  default.

**Two judgement calls worth flagging, please re-place either if you disagree:**

1. *Overlay instead of a real toolbar.* I tried the `NavigationStack` +
   `ToolbarItem(placement: .cancellationAction)` approach first, since that's
   what the rest of the app does and it gets genuine native chrome. It
   consistently broke the sheet sizing: the navigation bar's height falls
   outside what `presentationDetents([.height(contentHeight)])` measures, so
   the sheet came out too short and centered the overflowing content —
   clipping it at the top *and* bottom at once. I couldn't get the
   measurement to account for it reliably. An overlay takes no part in
   layout, so the existing sizing keeps working untouched. The tradeoff is
   that the circular X is styled by hand to resemble the native button
   rather than being one.
2. *Top-leading placement*, following `PlayerQueueView`. Most of the other
   sheets in the app put their close button top-*trailing*
   (`.topBarTrailing`), so there's a case for either.

Verified on `platform=macOS,variant=Mac Catalyst`: builds clean, and I
clicked through the Equalizer, Volume and Speed sheets in the running app —
close button works, content isn't clipped, EQ toggle renders as a switch.
