### PR TITLE
added configurable behavior for sleep timer when playback is paused

### DIFF
--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheetModel.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheetModel.swift
@@ -280,6 +280,21 @@ final class TimerPickerSheetViewModel: TimerPickerSheet.Model {
   }
 
   private func updateSleepTimer() {
+    if !player.isPlaying {
+      switch preferences.timerPauseBehavior {
+      case .none:
+        break
+      case .pause:
+        return
+      case .reset:
+        resetTimerToOriginalDuration()
+        return
+      case .off:
+        cancelTimerForPause()
+        return
+      }
+    }
+
     switch current {
     case .preset(let seconds):
       if seconds > 1 {
@@ -461,6 +476,35 @@ final class TimerPickerSheetViewModel: TimerPickerSheet.Model {
       AppLogger.player.info("Auto-timer activated: \(count) chapters")
 
     case .off:
+      break
+    }
+  }
+
+  private func resetTimerToOriginalDuration() {
+    guard originalTimerDuration > 0 else { return }
+
+    switch current {
+    case .preset(let seconds):
+      guard seconds != originalTimerDuration else { return }
+      current = .preset(originalTimerDuration)
+    case .custom(let seconds):
+      guard seconds != originalTimerDuration else { return }
+      current = .custom(originalTimerDuration)
+    case .chapters, .atTime, .duration, .none:
+      return
+    }
+
+    player.volume = Float(preferences.volumeLevel)
+    pauseLiveActivity()
+  }
+
+  private func cancelTimerForPause() {
+    switch current {
+    case .preset, .custom:
+      current = .none
+      stopSleepTimer()
+      player.volume = Float(preferences.volumeLevel)
+    case .chapters, .atTime, .duration, .none:
       break
     }
   }
@@ -700,10 +744,15 @@ extension TimerPickerSheetViewModel {
     let remainingTime: TimeInterval
     if let remaining {
       remainingTime = remaining
-    } else if case .chapters(let count) = current {
-      remainingTime = calculateChapterDuration(for: count) ?? 0
     } else {
-      remainingTime = 0
+      switch current {
+      case .preset(let seconds), .custom(let seconds):
+        remainingTime = seconds
+      case .chapters(let count):
+        remainingTime = calculateChapterDuration(for: count) ?? 0
+      case .atTime, .duration, .none:
+        remainingTime = 0
+      }
     }
 
     let state = SleepTimerActivityAttributes.ContentState(

--- a/AudioBooth/AudioBooth/Screens/Settings/Preferences/Player/SleepShake/SleepPreferencesView.swift
+++ b/AudioBooth/AudioBooth/Screens/Settings/Preferences/Player/SleepShake/SleepPreferencesView.swift
@@ -83,6 +83,17 @@ struct SleepPreferencesView: View {
           }
           .listRowBackground(theme.colors.background.card)
         }
+
+        VStack(alignment: .leading, spacing: 12) {
+          Text("Playback Pause Behavior")
+            .font(.subheadline)
+            .fontWeight(.medium)
+          TimerPauseBehaviorRow(selection: $preferences.timerPauseBehavior)
+          Text(preferences.timerPauseBehavior.explanation)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .listRowBackground(theme.colors.background.card)
       } header: {
         Text("Sleep Timer")
       }
@@ -145,6 +156,32 @@ struct SleepPreferencesView: View {
       return String(localized: "No Fade")
     }
     return Duration.seconds(value).formatted()
+  }
+}
+
+private struct TimerPauseBehaviorRow: View {
+  @Binding var selection: TimerPauseBehavior
+
+  var body: some View {
+    HStack(spacing: 8) {
+      ForEach(TimerPauseBehavior.allCases, id: \.self) { behavior in
+        Button {
+          selection = behavior
+        } label: {
+          Text(behavior.displayText)
+            .font(.subheadline)
+            .fontWeight(.semibold)
+            .foregroundStyle(selection == behavior ? Color.white : Color.primary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(
+              RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(selection == behavior ? Color.accentColor : Color.gray.opacity(0.12))
+            )
+        }
+        .buttonStyle(.plain)
+      }
+    }
   }
 }
 

--- a/AudioBooth/AudioBooth/Services/UserPreferences/UserPreferences+Cloud.swift
+++ b/AudioBooth/AudioBooth/Services/UserPreferences/UserPreferences+Cloud.swift
@@ -16,6 +16,7 @@ extension UserPreferences {
     "shakeSensitivity",
     "customTimerMinutes",
     "timerFadeOut",
+    "timerPauseBehavior",
     "alarmFadeOut",
     "lockScreenNextPreviousUsesChapters",
     "lockScreenAllowPlaybackPositionChange",

--- a/AudioBooth/AudioBooth/Services/UserPreferences/UserPreferences.swift
+++ b/AudioBooth/AudioBooth/Services/UserPreferences/UserPreferences.swift
@@ -60,6 +60,9 @@ final class UserPreferences: ObservableObject {
   @AppStorage("timerFadeOut")
   var timerFadeOut: Double = 30.0
 
+  @AppStorage("timerPauseBehavior")
+  var timerPauseBehavior: TimerPauseBehavior = .none
+
   @AppStorage("alarmFadeOut")
   var alarmFadeOut: Double = 10.0
 
@@ -449,6 +452,31 @@ extension AutoTimerMode: RawRepresentable {
       return "duration:\(duration)"
     case .chapters(let count):
       return "chapters:\(count)"
+    }
+  }
+}
+
+enum TimerPauseBehavior: String, CaseIterable {
+  case none
+  case pause
+  case reset
+  case off
+
+  var displayText: LocalizedStringResource {
+    switch self {
+    case .none: "None"
+    case .pause: "Pause"
+    case .reset: "Reset"
+    case .off: "Off"
+    }
+  }
+
+  var explanation: LocalizedStringResource {
+    switch self {
+    case .none: "Timer keeps counting down while playback is paused."
+    case .pause: "Timer pauses with playback and resumes on play."
+    case .reset: "Timer stops with playback and restarts in full on play."
+    case .off: "Pausing playback turns the sleep timer off."
     }
   }
 }


### PR DESCRIPTION
Added new new options that change the default behavior for the sleep timer when media is paused. Previously, the timer continued regardless of playback state, and that behavior has been maintained as "none" and kept as the default setting. Additional settings were added that either pause the timer when playback is paused, reset the timer (good for an alternative to shaking the device), or turn the timer off.
<img width="402" height="874" alt="image" src="https://github.com/user-attachments/assets/ae6cd3d0-b4cd-475b-9111-e53ba9619fb4" />
