### PR TITLE
added support for activating auto sleep timer with a focus intent

### DIFF
--- a/AudioBooth/AudioBooth/AppIntents/FocusFilterIntent.swift
+++ b/AudioBooth/AudioBooth/AppIntents/FocusFilterIntent.swift
@@ -1,0 +1,47 @@
+import AppIntents
+import Foundation
+
+struct FocusFilterIntent: SetFocusFilterIntent {
+  static let title: LocalizedStringResource = "Auto Sleep"
+  static let description = IntentDescription(
+    "Automatically starts a sleep timer while this Focus is on."
+  )
+
+  @Parameter(title: "Start Sleep Timer", default: false)
+  var startSleepTimer: Bool
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(
+      title: "Auto Sleep",
+      subtitle: startSleepTimer ? "Sleep timer on" : "Sleep timer off"
+    )
+  }
+
+  static func suggestedFocusFilters(
+    for context: FocusFilterSuggestionContext
+  ) async -> [FocusFilterIntent] {
+    let suggestion = FocusFilterIntent()
+    suggestion.startSleepTimer = true
+    return [suggestion]
+  }
+
+  static var isActive: Bool {
+    get async {
+      let filter = try? await Self.current
+      return filter?.startSleepTimer ?? false
+    }
+  }
+
+  func perform() async throws -> some IntentResult {
+    guard startSleepTimer,
+      UserPreferences.shared.autoTimerTrigger.includesFocus,
+      let playerModel = PlayerManager.shared.current,
+      let timer = playerModel.timer as? TimerPickerSheetViewModel
+    else {
+      return .result()
+    }
+
+    timer.activateFocusTimer()
+    return .result()
+  }
+}

--- a/AudioBooth/AudioBooth/AppIntents/FocusFilterIntent.swift
+++ b/AudioBooth/AudioBooth/AppIntents/FocusFilterIntent.swift
@@ -2,18 +2,17 @@ import AppIntents
 import Foundation
 
 struct FocusFilterIntent: SetFocusFilterIntent {
-  static let title: LocalizedStringResource = "Auto Sleep"
-  static let description = IntentDescription(
-    "Automatically starts a sleep timer while this Focus is on."
-  )
+  static let title: LocalizedStringResource = "Focus Features"
 
-  @Parameter(title: "Start Sleep Timer", default: false)
-  var startSleepTimer: Bool
+  @Parameter(title: "Start Sleep Timer")
+  var startSleepTimer: Bool?
+
+  private var isEnabled: Bool { startSleepTimer == true }
 
   var displayRepresentation: DisplayRepresentation {
     DisplayRepresentation(
-      title: "Auto Sleep",
-      subtitle: startSleepTimer ? "Sleep timer on" : "Sleep timer off"
+      title: "Focus Features",
+      subtitle: isEnabled ? "Sleep timer on" : "Sleep timer off"
     )
   }
 
@@ -28,12 +27,12 @@ struct FocusFilterIntent: SetFocusFilterIntent {
   static var isActive: Bool {
     get async {
       let filter = try? await Self.current
-      return filter?.startSleepTimer ?? false
+      return filter?.isEnabled ?? false
     }
   }
 
   func perform() async throws -> some IntentResult {
-    guard startSleepTimer,
+    guard isEnabled,
       UserPreferences.shared.autoTimerTrigger.includesFocus,
       let playerModel = PlayerManager.shared.current,
       let timer = playerModel.timer as? TimerPickerSheetViewModel

--- a/AudioBooth/AudioBooth/AppIntents/FocusFilterIntent.swift
+++ b/AudioBooth/AudioBooth/AppIntents/FocusFilterIntent.swift
@@ -33,7 +33,7 @@ struct FocusFilterIntent: SetFocusFilterIntent {
 
   func perform() async throws -> some IntentResult {
     guard isEnabled,
-      UserPreferences.shared.autoTimerTrigger.includesFocus,
+      UserPreferences.shared.autoTimerTrigger != .timeWindow,
       let playerModel = PlayerManager.shared.current,
       let timer = playerModel.timer as? TimerPickerSheetViewModel
     else {

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheetModel.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheetModel.swift
@@ -454,12 +454,12 @@ final class TimerPickerSheetViewModel: TimerPickerSheet.Model {
 
     guard mode != .off, current == .none else { return }
 
-    if trigger.includesTimeWindow, isInAutoTimerWindow() {
+    if trigger != .focus, isInAutoTimerWindow() {
       startAutoTimer(mode: mode)
       return
     }
 
-    guard trigger.includesFocus else { return }
+    guard trigger != .timeWindow else { return }
 
     Task { [weak self] in
       guard await FocusFilterIntent.isActive else { return }

--- a/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheetModel.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/Sheets/Timer/TimerPickerSheetModel.swift
@@ -450,14 +450,37 @@ final class TimerPickerSheetViewModel: TimerPickerSheet.Model {
 
   func activateAutoTimerIfNeeded() {
     let mode = preferences.autoTimerMode
+    let trigger = preferences.autoTimerTrigger
 
-    guard mode != .off,
+    guard mode != .off, current == .none else { return }
+
+    if trigger.includesTimeWindow, isInAutoTimerWindow() {
+      startAutoTimer(mode: mode)
+      return
+    }
+
+    guard trigger.includesFocus else { return }
+
+    Task { [weak self] in
+      guard await FocusFilterIntent.isActive else { return }
+      guard let self, self.current == .none else { return }
+      self.startAutoTimer(mode: self.preferences.autoTimerMode)
+    }
+  }
+
+  func activateFocusTimer() {
+    guard preferences.autoTimerMode != .off,
       current == .none,
-      isInAutoTimerWindow()
+      player.isPlaying
     else {
       return
     }
 
+    AppLogger.player.info("Focus enabled during playback - starting auto-timer")
+    startAutoTimer(mode: preferences.autoTimerMode)
+  }
+
+  private func startAutoTimer(mode: AutoTimerMode) {
     let position = player.time
 
     switch mode {

--- a/AudioBooth/AudioBooth/Screens/Settings/Preferences/Player/SleepShake/SleepPreferencesView.swift
+++ b/AudioBooth/AudioBooth/Screens/Settings/Preferences/Player/SleepShake/SleepPreferencesView.swift
@@ -60,7 +60,7 @@ struct SleepPreferencesView: View {
               .font(.subheadline)
               .fontWeight(.medium)
             AutoTimerTriggerRow(selection: $preferences.autoTimerTrigger)
-            if preferences.autoTimerTrigger.includesFocus {
+            if preferences.autoTimerTrigger != .timeWindow {
               Text(
                 "Add AudioBooth to any Focus under Settings → Focus → Focus Filters. The timer starts whenever that Focus is on."
               )
@@ -70,7 +70,7 @@ struct SleepPreferencesView: View {
           }
           .listRowBackground(theme.colors.background.card)
 
-          if preferences.autoTimerTrigger.includesTimeWindow {
+          if preferences.autoTimerTrigger != .focus {
             HStack {
               Text("Time Window")
                 .font(.subheadline)

--- a/AudioBooth/AudioBooth/Screens/Settings/Preferences/Player/SleepShake/SleepPreferencesView.swift
+++ b/AudioBooth/AudioBooth/Screens/Settings/Preferences/Player/SleepShake/SleepPreferencesView.swift
@@ -35,7 +35,7 @@ struct SleepPreferencesView: View {
             systemImage: "moon",
             tint: .purple,
             title: "Auto Sleep",
-            subtitle: "Start a timer when playing within a window."
+            subtitle: "Start a timer automatically while playing."
           )
         }
         .listRowBackground(theme.colors.background.card)
@@ -55,17 +55,34 @@ struct SleepPreferencesView: View {
           }
           .listRowBackground(theme.colors.background.card)
 
-          HStack {
-            Text("Time Window")
+          VStack(alignment: .leading, spacing: 12) {
+            Text("Start During")
               .font(.subheadline)
               .fontWeight(.medium)
-            Spacer()
-            TimePicker(minutesSinceMidnight: $preferences.autoTimerWindowStart)
-            Text(verbatim: "–")
+            AutoTimerTriggerRow(selection: $preferences.autoTimerTrigger)
+            if preferences.autoTimerTrigger.includesFocus {
+              Text(
+                "Add AudioBooth to any Focus under Settings → Focus → Focus Filters. The timer starts whenever that Focus is on."
+              )
+              .font(.caption)
               .foregroundStyle(.secondary)
-            TimePicker(minutesSinceMidnight: $preferences.autoTimerWindowEnd)
+            }
           }
           .listRowBackground(theme.colors.background.card)
+
+          if preferences.autoTimerTrigger.includesTimeWindow {
+            HStack {
+              Text("Time Window")
+                .font(.subheadline)
+                .fontWeight(.medium)
+              Spacer()
+              TimePicker(minutesSinceMidnight: $preferences.autoTimerWindowStart)
+              Text(verbatim: "–")
+                .foregroundStyle(.secondary)
+              TimePicker(minutesSinceMidnight: $preferences.autoTimerWindowEnd)
+            }
+            .listRowBackground(theme.colors.background.card)
+          }
 
           Picker(selection: $preferences.timerFadeOut) {
             ForEach(fadeOptions, id: \.self) { value in
@@ -156,6 +173,32 @@ struct SleepPreferencesView: View {
       return String(localized: "No Fade")
     }
     return Duration.seconds(value).formatted()
+  }
+}
+
+private struct AutoTimerTriggerRow: View {
+  @Binding var selection: AutoTimerTrigger
+
+  var body: some View {
+    HStack(spacing: 8) {
+      ForEach(AutoTimerTrigger.allCases, id: \.self) { trigger in
+        Button {
+          selection = trigger
+        } label: {
+          Text(trigger.displayText)
+            .font(.subheadline)
+            .fontWeight(.semibold)
+            .foregroundStyle(selection == trigger ? Color.white : Color.primary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(
+              RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(selection == trigger ? Color.accentColor : Color.gray.opacity(0.12))
+            )
+        }
+        .buttonStyle(.plain)
+      }
+    }
   }
 }
 

--- a/AudioBooth/AudioBooth/Services/UserPreferences/UserPreferences+Cloud.swift
+++ b/AudioBooth/AudioBooth/Services/UserPreferences/UserPreferences+Cloud.swift
@@ -42,6 +42,7 @@ extension UserPreferences {
     "autoTimerMode",
     "autoTimerWindowStart",
     "autoTimerWindowEnd",
+    "autoTimerTrigger",
     "playerOrientation",
     "colorScheme",
     "appTheme",

--- a/AudioBooth/AudioBooth/Services/UserPreferences/UserPreferences.swift
+++ b/AudioBooth/AudioBooth/Services/UserPreferences/UserPreferences.swift
@@ -464,9 +464,6 @@ enum AutoTimerTrigger: String, CaseIterable {
   case focus
   case either
 
-  var includesTimeWindow: Bool { self != .focus }
-  var includesFocus: Bool { self != .timeWindow }
-
   var displayText: LocalizedStringResource {
     switch self {
     case .timeWindow: "Time Window"

--- a/AudioBooth/AudioBooth/Services/UserPreferences/UserPreferences.swift
+++ b/AudioBooth/AudioBooth/Services/UserPreferences/UserPreferences.swift
@@ -171,6 +171,9 @@ final class UserPreferences: ObservableObject {
   @AppStorage("autoTimerWindowEnd")
   var autoTimerWindowEnd: Int = 6 * 60
 
+  @AppStorage("autoTimerTrigger")
+  var autoTimerTrigger: AutoTimerTrigger = .timeWindow
+
   @AppStorage("playerOrientation")
   var playerOrientation: PlayerOrientation = .auto
 
@@ -452,6 +455,23 @@ extension AutoTimerMode: RawRepresentable {
       return "duration:\(duration)"
     case .chapters(let count):
       return "chapters:\(count)"
+    }
+  }
+}
+
+enum AutoTimerTrigger: String, CaseIterable {
+  case timeWindow
+  case focus
+  case either
+
+  var includesTimeWindow: Bool { self != .focus }
+  var includesFocus: Bool { self != .timeWindow }
+
+  var displayText: LocalizedStringResource {
+    switch self {
+    case .timeWindow: "Time Window"
+    case .focus: "Focus"
+    case .either: "Either"
     }
   }
 }


### PR DESCRIPTION
Added an option to set auto sleep timer from a focus intent. This allows for more dynamic settings than the time window, but the original time window option was maintained as well.
<img width="402" height="874" alt="image" src="https://github.com/user-attachments/assets/c6b97385-143f-49d9-b8e4-4c155c19c05e" />
