### PR TITLE
Fix main-thread hang on Home from SwiftData progress observations

### DIFF
--- a/AudioBooth/AudioBooth/Screens/BookPlayer/BookPlayerModel.swift
+++ b/AudioBooth/AudioBooth/Screens/BookPlayer/BookPlayerModel.swift
@@ -232,6 +232,10 @@ final class BookPlayerModel: BookPlayer.Model {
     onLoad()
   }
 
+  isolated deinit {
+    itemObservation?.cancel()
+  }
+
   override var secondsFromStartOfBook: TimeInterval {
     player?.time ?? mediaProgress.currentTime
   }

--- a/AudioBooth/AudioBooth/Screens/Home/ContinueListening/ContinueListeningBookCardModel.swift
+++ b/AudioBooth/AudioBooth/Screens/Home/ContinueListening/ContinueListeningBookCardModel.swift
@@ -91,6 +91,10 @@ final class ContinueListeningBookCardModel: BookCard.Model {
     setupDownloadProgressObserver()
   }
 
+  isolated deinit {
+    progressObservation?.cancel()
+  }
+
   override func onAppear() {
     mediaProgress = try? MediaProgress.fetch(bookID: id)
   }

--- a/AudioBooth/AudioBooth/Screens/Library/Library/BookCard/PodcastCardModel.swift
+++ b/AudioBooth/AudioBooth/Screens/Library/Library/BookCard/PodcastCardModel.swift
@@ -75,6 +75,10 @@ final class PodcastCardModel: BookCard.Model {
     }
   }
 
+  isolated deinit {
+    progressObservation?.cancel()
+  }
+
   private func setupDownloadStateObserver() {
     let episodeID = id
     downloadStateCancellable = DownloadManager.shared.$downloadStates

--- a/Models/Sources/Models/PersistentModel+Observations.swift
+++ b/Models/Sources/Models/PersistentModel+Observations.swift
@@ -12,26 +12,17 @@ extension PersistentModel {
       let task = Task { @MainActor in
         let ctx = ModelContextProvider.shared.context
         let descriptor = FetchDescriptor<Self>()
-
-        // Reading a persisted property off a changed model faults it in, costing a separate
-        // store fetch per object. Resolve the match once, then track it by identifier so the
-        // notification loop compares identifiers instead of touching the store.
         var targetID: PersistentIdentifier?
 
-        func locateTarget() -> Self? {
-          do {
-            let items = try ctx.fetch(descriptor)
-            return items.first { $0[keyPath: keyPath] == value }
-          } catch {
-            AppLogger.persistence.error("Failed to fetch \(entityName) for observation: \(error)")
-            return nil
+        do {
+          let items = try ctx.fetch(descriptor)
+          if let model = items.first(where: { $0[keyPath: keyPath] == value }) {
+            targetID = model.persistentModelID
+            nonisolated(unsafe) let model = model
+            continuation.yield(model)
           }
-        }
-
-        if let model = locateTarget() {
-          targetID = model.persistentModelID
-          nonisolated(unsafe) let model = model
-          continuation.yield(model)
+        } catch {
+          AppLogger.persistence.error("Failed to fetch \(entityName) for observation: \(error)")
         }
 
         for await notification in NotificationCenter.default.notifications(
@@ -42,30 +33,35 @@ extension PersistentModel {
             let userInfo = notification.userInfo
           else { continue }
 
-          let inserts = Set((userInfo[NSInsertedObjectsKey] as? [PersistentIdentifier]) ?? [])
-          let updates = Set((userInfo[NSUpdatedObjectsKey] as? [PersistentIdentifier]) ?? [])
-          let deletes = Set((userInfo[NSDeletedObjectsKey] as? [PersistentIdentifier]) ?? [])
+          let inserts = (userInfo[NSInsertedObjectsKey] as? [PersistentIdentifier]) ?? []
+          let updates = (userInfo[NSUpdatedObjectsKey] as? [PersistentIdentifier]) ?? []
+          let deletes = (userInfo[NSDeletedObjectsKey] as? [PersistentIdentifier]) ?? []
 
           if let identifier = targetID, deletes.contains(identifier) {
             targetID = nil
           }
 
           if let identifier = targetID {
-            guard inserts.contains(identifier) || updates.contains(identifier) else { continue }
             guard
+              inserts.contains(identifier) || updates.contains(identifier),
               let matched = modelContext.model(for: identifier) as? Self,
               !matched.isDeleted
             else { continue }
 
             nonisolated(unsafe) let model = matched
             continuation.yield(model)
-          } else if inserts.contains(where: { $0.entityName == entityName }) {
-            // Nothing is being tracked yet, so only a newly inserted row can start
-            // matching. Re-resolve once rather than per changed object.
-            if let model = locateTarget() {
-              targetID = model.persistentModelID
-              nonisolated(unsafe) let model = model
+          } else {
+            for identifier in inserts where identifier.entityName == entityName {
+              guard
+                let matched = modelContext.model(for: identifier) as? Self,
+                !matched.isDeleted,
+                matched[keyPath: keyPath] == value
+              else { continue }
+
+              targetID = identifier
+              nonisolated(unsafe) let model = matched
               continuation.yield(model)
+              break
             }
           }
         }

--- a/Models/Sources/Models/PersistentModel+Observations.swift
+++ b/Models/Sources/Models/PersistentModel+Observations.swift
@@ -13,15 +13,25 @@ extension PersistentModel {
         let ctx = ModelContextProvider.shared.context
         let descriptor = FetchDescriptor<Self>()
 
-        do {
-          let items = try ctx.fetch(descriptor)
-          let model = items.first { $0[keyPath: keyPath] == value }
-          if let model {
-            nonisolated(unsafe) let model = model
-            continuation.yield(model)
+        // Reading a persisted property off a changed model faults it in, costing a separate
+        // store fetch per object. Resolve the match once, then track it by identifier so the
+        // notification loop compares identifiers instead of touching the store.
+        var targetID: PersistentIdentifier?
+
+        func locateTarget() -> Self? {
+          do {
+            let items = try ctx.fetch(descriptor)
+            return items.first { $0[keyPath: keyPath] == value }
+          } catch {
+            AppLogger.persistence.error("Failed to fetch \(entityName) for observation: \(error)")
+            return nil
           }
-        } catch {
-          AppLogger.persistence.error("Failed to fetch \(entityName) for observation: \(error)")
+        }
+
+        if let model = locateTarget() {
+          targetID = model.persistentModelID
+          nonisolated(unsafe) let model = model
+          continuation.yield(model)
         }
 
         for await notification in NotificationCenter.default.notifications(
@@ -32,23 +42,31 @@ extension PersistentModel {
             let userInfo = notification.userInfo
           else { continue }
 
-          let inserts = (userInfo[NSInsertedObjectsKey] as? [PersistentIdentifier]) ?? []
-          let updates = (userInfo[NSUpdatedObjectsKey] as? [PersistentIdentifier]) ?? []
-          let deletes = (userInfo[NSDeletedObjectsKey] as? [PersistentIdentifier]) ?? []
+          let inserts = Set((userInfo[NSInsertedObjectsKey] as? [PersistentIdentifier]) ?? [])
+          let updates = Set((userInfo[NSUpdatedObjectsKey] as? [PersistentIdentifier]) ?? [])
+          let deletes = Set((userInfo[NSDeletedObjectsKey] as? [PersistentIdentifier]) ?? [])
 
-          let allChanges = inserts + updates
+          if let identifier = targetID, deletes.contains(identifier) {
+            targetID = nil
+          }
 
-          for identifier in allChanges {
+          if let identifier = targetID {
+            guard inserts.contains(identifier) || updates.contains(identifier) else { continue }
             guard
-              identifier.entityName == entityName,
-              !deletes.contains(identifier),
-              let model = modelContext.model(for: identifier) as? Self,
-              !model.isDeleted,
-              model[keyPath: keyPath] == value
+              let matched = modelContext.model(for: identifier) as? Self,
+              !matched.isDeleted
             else { continue }
 
-            nonisolated(unsafe) let value = model
-            continuation.yield(value)
+            nonisolated(unsafe) let model = matched
+            continuation.yield(model)
+          } else if inserts.contains(where: { $0.entityName == entityName }) {
+            // Nothing is being tracked yet, so only a newly inserted row can start
+            // matching. Re-resolve once rather than per changed object.
+            if let model = locateTarget() {
+              targetID = model.persistentModelID
+              nonisolated(unsafe) let model = model
+              continuation.yield(model)
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes #371.

On a podcast-only library the Home screen blocks the main thread long enough that KSCrash's deadlock
watchdog terminates the app. Two independent causes, one commit each — either can be taken on its own.

### Avoid faulting every changed model in SwiftData observations

`PersistentModel.observe(where:equals:)` read a persisted property off every changed object to test it:

```swift
model[keyPath: keyPath] == value
```

On a SwiftData `@Model` that read faults the object in, so each one costs a separate
`NSManagedObjectContext.fetch` (with its own `sqlite3_prepare_v3`), and the whole loop runs on the
MainActor. With ~1,700 `MediaProgress` rows and 26 observing Home cards that's roughly 44,000 synchronous
SQLite fetches per sync.

This resolves the match once and tracks it by `PersistentIdentifier`, so the notification loop compares
identifiers instead of touching the store. A fault knows its identity without being fulfilled, so this
answers the same question with no I/O. It falls back to re-resolving only when a row of that entity is
inserted and nothing is being tracked yet.

### Cancel media progress observations when the owning models are released

`ContinueListeningBookCardModel`, `PodcastCardModel` and `BookPlayerModel` start
`progressObservation = Task { ... }` but never cancel it. Releasing a `Task` handle doesn't cancel the
task, so each one stayed parked on `ModelContext.didSave` for the life of the process, and every rebuild
of the Home sections added more. `BookDetailsViewModel` already cancelled its observations in `deinit`;
this applies the same pattern to the other three.

### Verification

Built and run on the iPhone 17 Pro simulator (iOS 26.5) against the same account from #371 (single
podcast library, 1,708 `MediaProgress` rows).

| | before | after |
|---|---|---|
| CPU after launch | ramps to ~192%, stays ~155% | brief launch spike, then 0.0% at rest |
| Scrolling Home | main thread 100% busy, 0% idle | ~16%, settles immediately |
| Outcome | killed by the watchdog in ~14s | stable |

`PersistentModel.observe` no longer appears anywhere in main-thread samples after launch.

### Not addressed here

Two related things I left alone, since they're behaviour changes rather than fixes to this hang — happy
to add either if you'd like them in scope:

- `MediaProgress.update(from:)` assigns `id`, `duration` and `startedAt` before the
  `remoteLastUpdate > lastUpdate` check, which dirties every row `syncFromAPI` touches and puts all of
  them in each `didSave`.
- `ContentView` builds `HomePage(model: HomePageModel())` inline in `body` while the other tabs use a
  stored `@StateObject`. That's what made the leaked observers compound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
