### PR TITLE
Keep the screen awake while Read Along is following

### DIFF
--- a/AudioBooth/AudioBooth/Screens/EbookReader/EbookReaderView.swift
+++ b/AudioBooth/AudioBooth/Screens/EbookReader/EbookReaderView.swift
@@ -117,8 +117,14 @@ struct EbookReaderView: View {
         EbookPlayerSheet(player: player)
       }
     }
-    .onAppear(perform: model.onAppear)
-    .onDisappear(perform: model.onDisappear)
+    .onAppear {
+      UIApplication.shared.isIdleTimerDisabled = userPreferences.keepScreenAwakeInPlayer
+      model.onAppear()
+    }
+    .onDisappear {
+      UIApplication.shared.isIdleTimerDisabled = false
+      model.onDisappear()
+    }
     .statusBarHidden(true)
     .preferredColorScheme(preferredColorScheme)
     .background {


### PR DESCRIPTION
## Problem

The Keep Screen Awake preference only applies to the full player. Read Along runs inside the ebook reader, which never touched the idle timer, so the phone locked mid-chapter.

The reader now disables the idle timer while Read Along is active and the audiobook is playing, and restores it on pause, stop, failure, or when the reader closes. Plain ebook reading is unchanged.

Reported in Discord by @tenthrow.

## Behavior

The ebook reader now honors "Keep Screen Awake" the same way the player does. With the preference on, the screen stays awake while the reader is open, regardless of whether audio is playing or Read Along is active. With it off, normal auto-lock applies. Closing the reader restores the idle timer.

## Implementation

One file, `EbookReaderView.swift`. `onAppear` sets `isIdleTimerDisabled` from `userPreferences.keepScreenAwakeInPlayer`; `onDisappear` clears it. Mirrors `BookPlayer`. The `onChange` half of the player's pattern is omitted because Settings can't be open while the reader is presented.

## Tested on device (Auto-Lock at 30s, launched from home screen, no debugger)

- [x] Preference on, reader open with Read Along running: stays awake
- [x] Preference on, reader open, audio paused: stays awake
- [x] Preference on, reader open, plain ebook (no audio): stays awake
- [x] Preference off, reader open with Read Along running: locks on schedule
- [x] Close the reader: locks on schedule afterward