### PR TITLE
*first attempt for russian localization (#364)

### DIFF
--- a/AudioBooth/AudioBooth/Localizable.xcstrings
+++ b/AudioBooth/AudioBooth/Localizable.xcstrings
@@ -33,6 +33,12 @@
             "value" : ""
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -79,6 +85,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Velocità in bit :** %lld kbps"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Битрейт:** %lld кбит/с"
           }
         },
         "zh-Hans" : {
@@ -135,6 +147,12 @@
             "value" : "**Canale :** %1$lld (%2$@)"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Канал:** %1$lld (%2$@)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -181,6 +199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Codec :** %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Кодек:** %@"
           }
         },
         "zh-Hans" : {
@@ -231,6 +255,12 @@
             "value" : "**Durata :** %@"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Длительность:** %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -277,6 +307,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Episodi :** %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Эпизодов:** %lld"
           }
         },
         "zh-Hans" : {
@@ -327,6 +363,12 @@
             "value" : "**Lingua :** %@"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Язык:** %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -373,6 +415,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Pubblicato :** %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Год публикации:** %@"
           }
         },
         "zh-Hans" : {
@@ -423,6 +471,12 @@
             "value" : "**Editore :** %@"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Издательство:** %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -469,6 +523,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Dimensione :** %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Размер:** %@"
           }
         },
         "zh-Hans" : {
@@ -519,6 +579,12 @@
             "value" : "**Tipo :** %@"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Тип:** %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -567,6 +633,12 @@
             "value" : "# di episodi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Эпизоду"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -610,6 +682,12 @@
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@"
@@ -663,6 +741,12 @@
             "value" : "%@ autore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ автор"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -709,6 +793,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ completato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ прослушано"
           }
         },
         "zh-Hans" : {
@@ -759,6 +849,12 @@
             "value" : "%@ rimanenti"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Осталось %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -805,6 +901,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ narratore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Диктор %@"
           }
         },
         "zh-Hans" : {
@@ -861,6 +963,12 @@
             "value" : "%1$@ di %2$@"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ из %2$@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -909,6 +1017,12 @@
             "value" : "%@ rimanenti"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Осталось %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -952,6 +1066,12 @@
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld"
@@ -1003,6 +1123,36 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld libri"
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книги"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книг"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книга"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книги"
+                }
+              }
+            }
           }
         },
         "zh-Hans" : {
@@ -1059,6 +1209,12 @@
             "value" : "%lld capitolo %@"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld гл. · %2$@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1105,6 +1261,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pausa di %lld h"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пауза %lld ч"
           }
         },
         "zh-Hans" : {
@@ -1161,6 +1323,12 @@
             "value" : "%lld min · %@"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld мин · %2$@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1207,6 +1375,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pausa di %lld min"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пауза %lld мин"
           }
         },
         "zh-Hans" : {
@@ -1263,6 +1437,12 @@
             "value" : "%1$lld di %2$lld selezionati"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрано %1$lld из %2$lld"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1308,6 +1488,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld selezionati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрано: %lld"
           }
         },
         "zh-Hans" : {
@@ -1358,6 +1544,12 @@
             "value" : "%lld s"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld с"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1404,6 +1596,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pausa di %lld s"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пауза %lld с"
           }
         },
         "zh-Hans" : {
@@ -1454,6 +1652,36 @@
             "value" : "^[%lld autore](inflect: true)"
           }
         },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld автора"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld авторов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld автор"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld автора"
+                }
+              }
+            }
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1500,6 +1728,36 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "^[%lld libro](inflect: true)"
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книги"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книг"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книга"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книги"
+                }
+              }
+            }
           }
         },
         "zh-Hans" : {
@@ -1550,6 +1808,36 @@
             "value" : "^[%lld Libro](inflect: true)"
           }
         },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книги"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книг"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книга"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld книги"
+                }
+              }
+            }
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1596,6 +1884,36 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "^[%lld raccolta](inflect: true)"
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld подборки"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld подборок"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld подборка"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld подборки"
+                }
+              }
+            }
           }
         },
         "zh-Hans" : {
@@ -1646,6 +1964,36 @@
             "value" : "^[%lld giorno](inflect: true)"
           }
         },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld дня"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld дней"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld день"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld дня"
+                }
+              }
+            }
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1694,6 +2042,36 @@
             "value" : "^[%lld elemento](inflect: true)"
           }
         },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld элемента"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld элементов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld элемент"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld элемента"
+                }
+              }
+            }
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1738,6 +2116,36 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "^[%lld elemento](inflect: true)"
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld элемента"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld элементов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld элемент"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld элемента"
+                }
+              }
+            }
           }
         },
         "zh-Hans" : {
@@ -1788,6 +2196,12 @@
             "value" : "Ancora ^[%lld min](inflect: true) oggi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Осталось %lld мин до выполнения цели"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1834,6 +2248,36 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "^[%lld playlist](inflect: true)"
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld плейлиста"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld плейлистов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld плейлист"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld плейлиста"
+                }
+              }
+            }
           }
         },
         "zh-Hans" : {
@@ -1884,6 +2328,36 @@
             "value" : "^[%lld podcast](inflect: true)"
           }
         },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld подкаста"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld подкастов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld подкаст"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld подкаста"
+                }
+              }
+            }
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1932,6 +2406,36 @@
             "value" : "^[%lld serie](inflect: true)"
           }
         },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld цикла"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld циклов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld цикл"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld цикла"
+                }
+              }
+            }
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1942,1018 +2446,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "^[%lld 個系列](inflect: true)"
-          }
-        }
-      }
-    },
-    "Always for This Book" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altid for denne bog"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Immer für dieses Buch"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Siempre para este libro"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toujours pour ce livre"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sempre per questo libro"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此书始终隐藏"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此書始終隱藏"
-          }
-        }
-      }
-    },
-    "Catch Up" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indhent"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufholen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ponerse al día"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rattrapage"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recupero"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追上进度"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追上進度"
-          }
-        }
-      }
-    },
-    "Catch Up needs iOS 26 or later." : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indhent kræver iOS 26 eller nyere."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufholen erfordert iOS 26 oder neuer."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ponerse al día requiere iOS 26 o posterior."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rattrapage nécessite iOS 26 ou une version ultérieure."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recupero richiede iOS 26 o versioni successive."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追上进度需要 iOS 26 或更高版本。"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追上進度需要 iOS 26 或以上版本。"
-          }
-        }
-      }
-    },
-    "Couldn't find your reading position in %@. That part may not be narrated in this recording." : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kunne ikke finde din læseposition i %@. Den del er måske ikke indlæst i denne optagelse."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deine Leseposition konnte in %@ nicht gefunden werden. Dieser Teil ist in dieser Aufnahme möglicherweise nicht enthalten."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo encontrar tu posición de lectura en %@. Puede que esa parte no esté narrada en esta grabación."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de trouver votre position de lecture dans %@. Cette partie n'est peut-être pas narrée dans cet enregistrement."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non è stato possibile trovare la tua posizione di lettura in %@. Quella parte potrebbe non essere narrata in questa registrazione."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未能在%@中找到你的阅读位置。此录音中可能没有朗读这一部分。"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未能在%@中找到你的閱讀位置。此錄音中可能沒有朗讀這一部分。"
-          }
-        }
-      }
-    },
-    "Couldn't find your reading position in the audiobook. It may not be narrated in this recording." : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kunne ikke finde din læseposition i lydbogen. Den er måske ikke indlæst i denne optagelse."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deine Leseposition konnte im Hörbuch nicht gefunden werden. Sie ist in dieser Aufnahme möglicherweise nicht enthalten."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo encontrar tu posición de lectura en el audiolibro. Puede que no esté narrada en esta grabación."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de trouver votre position de lecture dans le livre audio. Elle n'est peut-être pas narrée dans cet enregistrement."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non è stato possibile trovare la tua posizione di lettura nell'audiolibro. Potrebbe non essere narrata in questa registrazione."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未能在有声书中找到你的阅读位置。此录音中可能没有朗读这一部分。"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未能在有聲書中找到你的閱讀位置。此錄音中可能沒有朗讀這一部分。"
-          }
-        }
-      }
-    },
-    "Couldn't tell where you stopped reading. Open the ebook first." : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kunne ikke afgøre, hvor du stoppede med at læse. Åbn e-bogen først."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es ließ sich nicht feststellen, wo du aufgehört hast zu lesen. Öffne zuerst das E-Book."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo determinar dónde dejaste de leer. Abre primero el libro electrónico."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de déterminer où vous vous êtes arrêté de lire. Ouvrez d'abord l'ebook."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non è stato possibile capire dove hai smesso di leggere. Apri prima l'ebook."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法确定你的阅读位置。请先打开电子书。"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法確定你的閱讀位置。請先開啟電子書。"
-          }
-        }
-      }
-    },
-    "Dismiss" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afvis"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausblenden"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descartar"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignora"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "關閉"
-          }
-        }
-      }
-    },
-    "Download this audiobook to catch up." : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hent denne lydbog for at indhente."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lade dieses Hörbuch herunter, um aufzuholen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descarga este audiolibro para ponerte al día."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Téléchargez ce livre audio pour rattraper votre lecture."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scarica questo audiolibro per recuperare."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请下载此有声书以追上进度。"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "請下載此有聲書以追上進度。"
-          }
-        }
-      }
-    },
-    "Download this book's ebook to catch up." : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hent denne bogs e-bog for at indhente."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lade das E-Book zu diesem Buch herunter, um aufzuholen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descarga el libro electrónico de este libro para ponerte al día."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Téléchargez l'ebook de ce livre pour rattraper votre lecture."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scarica l'ebook di questo libro per recuperare."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请下载这本书的电子书以追上进度。"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "請下載這本書的電子書以追上進度。"
-          }
-        }
-      }
-    },
-    "Finding where the narrator is…" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finder, hvor oplæseren er…"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suche, wo der Sprecher gerade ist…"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscando dónde va el narrador…"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recherche de la position du narrateur…"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ricerca del punto in cui si trova il narratore…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在查找朗读者的位置…"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在尋找朗讀者的位置…"
-          }
-        }
-      }
-    },
-    "Finding where you stopped reading…" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finder, hvor du stoppede med at læse…"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suche, wo du aufgehört hast zu lesen…"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscando dónde dejaste de leer…"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recherche de l'endroit où vous vous êtes arrêté…"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ricerca del punto in cui hai smesso di leggere…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在查找你的阅读位置…"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在尋找你的閱讀位置…"
-          }
-        }
-      }
-    },
-    "For Now" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indtil videre"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorerst"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por ahora"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pour l'instant"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Per ora"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暂时隐藏"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暫時隱藏"
-          }
-        }
-      }
-    },
-    "Getting ready… %lld%%" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gør klar… %lld %%"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird vorbereitet… %lld %%"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando… %lld %%"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Préparation… %lld %%"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparazione… %lld %%"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在准备… %lld%%"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在準備… %lld%%"
-          }
-        }
-      }
-    },
-    "Hide this banner?" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skjul dette banner?"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Banner ausblenden?"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Ocultar este aviso?"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Masquer cette bannière ?"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vuoi nascondere questo banner?"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "隐藏此横幅？"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "隱藏此橫幅？"
-          }
-        }
-      }
-    },
-    "Listening for the last words you read. This can take a minute." : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lytter efter de sidste ord, du læste. Det kan tage et minut."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es wird nach den letzten Wörtern gesucht, die du gelesen hast. Das kann einen Moment dauern."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscando las últimas palabras que leíste. Esto puede tardar un minuto."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recherche des derniers mots que vous avez lus. Cela peut prendre une minute."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ricerca delle ultime parole che hai letto. Può richiedere un minuto."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在聆听你最后读到的内容。这可能需要一分钟。"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在聆聽你最後讀到的內容。這可能需要一分鐘。"
-          }
-        }
-      }
-    },
-    "Offer to Catch Up" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilbyd at indhente"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufholen vorschlagen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ofrecer ponerse al día"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proposer le rattrapage"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proponi il recupero"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "提示追上进度"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "提示追上進度"
-          }
-        }
-      }
-    },
-    "Skip to Here" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spring hertil"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hierher springen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saltar aquí"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aller ici"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vai qui"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跳转到此处"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跳至此處"
-          }
-        }
-      }
-    },
-    "Suggest skipping ahead when you've read further than you've listened" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Foreslå at springe frem, når du har læst længere, end du har lyttet"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorschlagen vorzuspulen, wenn du weiter gelesen als gehört hast"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sugerir avanzar cuando hayas leído más de lo que has escuchado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proposer d'avancer quand vous avez lu plus loin que vous n'avez écouté"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proponi di saltare avanti quando hai letto più di quanto hai ascoltato"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当你阅读的进度超过收听进度时，提示向前跳转"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "當你閱讀的進度超過收聽進度時，提示向前跳轉"
-          }
-        }
-      }
-    },
-    "The audiobook is about ^[%lld page](inflect: true) ahead." : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lydbogen er omkring ^[%lld side](inflect: true) foran."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Hörbuch ist etwa ^[%lld Seite](inflect: true) voraus."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El audiolibro va unas ^[%lld página](inflect: true) por delante."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le livre audio a environ ^[%lld page](inflect: true) d'avance."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'audiolibro è avanti di circa ^[%lld pagina](inflect: true)."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有声书大约领先 %lld 页。"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有聲書大約領先 %lld 頁。"
-          }
-        }
-      }
-    },
-    "Until Next Session" : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Til næste gang"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bis zum nächsten Mal"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hasta la próxima sesión"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jusqu'à la prochaine session"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fino alla prossima sessione"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "直到下次使用"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "直到下次使用"
-          }
-        }
-      }
-    },
-    "You've listened about %@ further than you've read." : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du har lyttet omkring %@ længere, end du har læst."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du hast etwa %@ weiter gehört als gelesen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Has escuchado unos %@ más de lo que has leído."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous avez écouté environ %@ de plus que vous n'avez lu."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hai ascoltato circa %@ in più di quanto hai letto."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你的收听进度比阅读进度快约 %@。"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你的收聽進度比閱讀進度快約 %@。"
-          }
-        }
-      }
-    },
-    "You've read about %@ further than you've listened." : {
-      "localizations" : {
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du har læst omkring %@ længere, end du har lyttet."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du hast etwa %@ weiter gelesen als gehört."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Has leído unos %@ más de lo que has escuchado."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous avez lu environ %@ de plus que vous n'avez écouté."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hai letto circa %@ in più di quanto hai ascoltato."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你的阅读进度比收听进度快约 %@。"
-          }
-        },
-        "zh-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你的閱讀進度比收聽進度快約 %@。"
           }
         }
       }
@@ -2990,6 +2482,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "→ %.1f s indietro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "→ откат %.1f с"
           }
         },
         "zh-Hans" : {
@@ -3040,6 +2538,36 @@
             "value" : "≈ ^[%lld giorno](inflect: true) di riproduzione continua"
           }
         },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "≈ %lld дня непрерывного прослушивания"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "≈ %lld дней непрерывного прослушивания"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "≈ %lld день непрерывного прослушивания"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "≈ %lld дня непрерывного прослушивания"
+                }
+              }
+            }
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3086,6 +2614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "1 libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 книга"
           }
         },
         "zh-Hans" : {
@@ -3136,6 +2670,12 @@
             "value" : "2 episodi più recenti"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 последних выпуска"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3182,6 +2722,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "3 episodi più recenti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3 последних выпуска"
           }
         },
         "zh-Hans" : {
@@ -3232,6 +2778,12 @@
             "value" : "5 episodi più recenti"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 последних выпусков"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3278,6 +2830,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "10 episodi più recenti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 последних выпусков"
           }
         },
         "zh-Hans" : {
@@ -3374,6 +2932,12 @@
             "value" : "Informazioni"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Об авторе"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3420,6 +2984,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ridotto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сокращённая версия"
           }
         },
         "zh-Hans" : {
@@ -3470,6 +3040,12 @@
             "value" : "Colore di evidenziazione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Акцентный цвет"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3516,6 +3092,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Profilo utente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аккаунт"
           }
         },
         "zh-Hans" : {
@@ -3566,6 +3148,12 @@
             "value" : "Attività"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Активность"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3612,6 +3200,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aggiungi **audiobooth://oauth** agli URI di reindirizzamento del server Audiobookshelf"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавьте **audiobooth://oauth** в список redirect URI на сервере audiobookshelf"
           }
         },
         "zh-Hans" : {
@@ -3662,6 +3256,12 @@
             "value" : "Aggiungi un segnalibro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить закладку"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3708,6 +3308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aggiungi AudioBooth a qualsiasi Full Immersion in Impostazioni → Full Immersion → Filtri Full Immersion. Il timer si avvia quando quella Full Immersion è attiva."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавьте AudioBooth в любой режим фокусирования: «Настройки» → «Фокусирование» → «Фильтры фокусирования». Таймер запускается, когда этот режим включён."
           }
         },
         "zh-Hans" : {
@@ -3758,6 +3364,12 @@
             "value" : "Aggiungi segnalibro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить закладку"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3802,6 +3414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aggiungi segnalibro ${content}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить закладку ${content}"
           }
         },
         "zh-Hans" : {
@@ -3852,6 +3470,12 @@
             "value" : "Aggiungi libri alla coda dalla libreria"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавляйте книги в очередь из библиотеки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3898,6 +3522,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aggiungi titolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить заголовок"
           }
         },
         "zh-Hans" : {
@@ -3948,6 +3578,12 @@
             "value" : "Aggiungi un server"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить сервер"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3994,6 +3630,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aggiungi a una raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить в подборку"
           }
         },
         "zh-Hans" : {
@@ -4044,6 +3686,12 @@
             "value" : "Aggiungi a una playlist"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить в плейлист"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4090,6 +3738,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aggiungi alla coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить в очередь"
           }
         },
         "zh-Hans" : {
@@ -4186,6 +3840,12 @@
             "value" : "Aggiunge un segnalibro alla posizione corrente dell’audiolibro in riproduzione."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавляет закладку в текущей позиции воспроизводимой аудиокниги."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4232,6 +3892,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modifica progresso capitolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пересчитывать время главы"
           }
         },
         "zh-Hans" : {
@@ -4282,6 +3948,12 @@
             "value" : "Regola il tempo rimanente in base alla velocità di riproduzione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пересчитывать остаток времени"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4328,6 +4000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avanzate"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дополнительно"
           }
         },
         "zh-Hans" : {
@@ -4378,6 +4056,12 @@
             "value" : "Tipografia avanzata"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Расширенная типографика"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4424,6 +4108,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sveglia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Будильник"
           }
         },
         "zh-Hans" : {
@@ -4474,6 +4164,12 @@
             "value" : "Ora della sveglia"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время будильника"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4520,6 +4216,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tipo di sveglia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тип будильника"
           }
         },
         "zh-Hans" : {
@@ -4570,6 +4272,12 @@
             "value" : "Alias (facoltativo)"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Псевдоним (необязательно)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4615,6 +4323,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vedi tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все"
           }
         },
         "zh-Hans" : {
@@ -4663,6 +4377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tutti i nuovi episodi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все новые выпуски"
           }
         },
         "zh-Hans" : {
@@ -4759,6 +4479,12 @@
             "value" : "ASCOLTO TOTALE"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ВСЁ ВРЕМЯ ПРОСЛУШИВАНИЯ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4805,6 +4531,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Consenti ricerca"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разрешить перемотку"
           }
         },
         "zh-Hans" : {
@@ -4855,6 +4587,12 @@
             "value" : "Sei già al primo capitolo."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это уже первая глава."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4901,6 +4639,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sei già all'ultimo capitolo."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это уже последняя глава."
           }
         },
         "zh-Hans" : {
@@ -4951,6 +4695,12 @@
             "value" : "Alternativo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Альтернативный"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4999,6 +4749,12 @@
             "value" : "URL alternativo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Альтернативный URL"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5009,6 +4765,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "替代網址"
+          }
+        }
+      }
+    },
+    "Always for This Book" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altid for denne bog"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immer für dieses Buch"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siempre para este libro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toujours pour ce livre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sempre per questo libro"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此书始终隐藏"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此書始終隱藏"
           }
         }
       }
@@ -5045,6 +4847,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sempre visibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Всегда видно"
           }
         },
         "zh-Hans" : {
@@ -5095,6 +4903,12 @@
             "value" : "Un URL alternativo da usare quando ti connetti da una rete diversa (ad esempio da casa)."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Альтернативный URL для подключения из другой сети (например, из дома)."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5141,6 +4955,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chiave API"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ"
           }
         },
         "zh-Hans" : {
@@ -5191,6 +5011,12 @@
             "value" : "Icona dell'app"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Значок приложения"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5237,6 +5063,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aspetto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оформление"
           }
         },
         "zh-Hans" : {
@@ -5287,6 +5119,12 @@
             "value" : "Aggiungi il tempo rimanente al titolo nella schermata di blocco"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавлять остаток времени к заголовку на экране блокировки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5333,6 +5171,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sei sicuro di voler rimuovere questa raccolta?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить эту подборку?"
           }
         },
         "zh-Hans" : {
@@ -5383,6 +5227,12 @@
             "value" : "Sei sicuro di voler rimuovere la tua playlist \"%@\"?"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить плейлист «%@»?"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5429,6 +5279,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "All’ora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В заданное время"
           }
         },
         "zh-Hans" : {
@@ -5479,6 +5335,12 @@
             "value" : "Dissolvenza in uscita audio"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Плавное затухание звука"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5525,6 +5387,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Interruzioni audio"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прерывания звука"
           }
         },
         "zh-Hans" : {
@@ -5575,6 +5443,12 @@
             "value" : "Audiolibro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аудиокнига"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5623,6 +5497,12 @@
             "value" : "Audiolibri"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аудиокниги"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5669,6 +5549,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Audiolibri e Libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аудиокниги и электронные книги"
           }
         },
         "zh-Hans" : {
@@ -5765,6 +5651,12 @@
             "value" : "Sveglia AudioBooth"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Будильник AudioBooth"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5859,6 +5751,12 @@
             "value" : "Accedi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Войти"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5905,6 +5803,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Accesso in corso..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аутентификация..."
           }
         },
         "zh-Hans" : {
@@ -5955,6 +5859,12 @@
             "value" : "Accedi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аутентификация"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6001,6 +5911,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Errore di autenticazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ошибка аутентификации"
           }
         },
         "zh-Hans" : {
@@ -6051,6 +5967,12 @@
             "value" : "Metodo di autenticazione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Способ аутентификации"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6097,6 +6019,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Accesso richiesto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Требуется аутентификация"
           }
         },
         "zh-Hans" : {
@@ -6147,6 +6075,12 @@
             "value" : "Autore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автор"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6193,6 +6127,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autore (cognome, nome)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автор (фамилия, имя)"
           }
         },
         "zh-Hans" : {
@@ -6243,6 +6183,12 @@
             "value" : "Nome dell'autore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя автора"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6289,6 +6235,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autori"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Авторы"
           }
         },
         "zh-Hans" : {
@@ -6339,6 +6291,12 @@
             "value" : "Automatica"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Авто"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6385,6 +6343,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scorrimento automatico"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автопрокрутка"
           }
         },
         "zh-Hans" : {
@@ -6435,6 +6399,12 @@
             "value" : "Sospensione automatica"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автотаймер сна"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6483,6 +6453,12 @@
             "value" : "Aggiungi automaticamente i nuovi episodi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автодобавление новых выпусков"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6527,6 +6503,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rimuovi automaticamente i libri non aperti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически удалять книги, которые вы не открывали"
           }
         },
         "zh-Hans" : {
@@ -6577,6 +6559,12 @@
             "value" : "Download automatico"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автозагрузка"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6625,6 +6613,12 @@
             "value" : "Download automatico libri"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автозагрузка книг"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6669,6 +6663,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scarica automaticamente gli episodi in coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автозагрузка выпусков из очереди"
           }
         },
         "zh-Hans" : {
@@ -6719,6 +6719,12 @@
             "value" : "Riproduci automaticamente il successivo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автовоспроизведение следующего"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6765,6 +6771,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riproduci automaticamente il successivo in coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автовоспроизведение следующего в очереди"
           }
         },
         "zh-Hans" : {
@@ -6815,6 +6827,12 @@
             "value" : "Riavvolgi automaticamente alla ripresa"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автооткат при продолжении"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6861,6 +6879,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riproduci automaticamente il libro successivo della serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически воспроизводить следующую книгу цикла"
           }
         },
         "zh-Hans" : {
@@ -6911,6 +6935,12 @@
             "value" : "Riproduci automaticamente il libro scaricato successivo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически воспроизводить следующую загруженную книгу"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6959,6 +6989,12 @@
             "value" : "Riproduci automaticamente l'episodio di podcast successivo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически воспроизводить следующий выпуск подкаста"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7005,6 +7041,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Indietro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Назад"
           }
         },
         "zh-Hans" : {
@@ -7061,6 +7103,12 @@
             "value" : "Indietro %llds · Avanti %llds"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Назад %1$lld с · Вперёд %2$lld с"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7109,6 +7157,12 @@
             "value" : "Comportamento"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поведение"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7153,6 +7207,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nero"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чёрный"
           }
         },
         "zh-Hans" : {
@@ -7203,6 +7263,12 @@
             "value" : "Blu"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синий"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7249,6 +7315,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dettagli del libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сведения о книге"
           }
         },
         "zh-Hans" : {
@@ -7299,6 +7371,12 @@
             "value" : "Dettagli del Libro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сведения о книге"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7345,6 +7423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Segnalibro aggiunto a %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закладка добавлена в «%@»"
           }
         },
         "zh-Hans" : {
@@ -7395,6 +7479,12 @@
             "value" : "Titolo del segnalibro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название закладки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7441,6 +7531,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Segnialibri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закладки"
           }
         },
         "zh-Hans" : {
@@ -7491,6 +7587,12 @@
             "value" : "Libri"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книги"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7537,6 +7639,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "I libri e gli episodi scaricati compariranno qui."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Здесь появятся загруженные книги и выпуски."
           }
         },
         "zh-Hans" : {
@@ -7633,6 +7741,12 @@
             "value" : "Bordo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Рамка"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7679,6 +7793,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fondo della coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В конец очереди"
           }
         },
         "zh-Hans" : {
@@ -7729,6 +7849,12 @@
             "value" : "Chiamate, sveglie, altri audio"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Звонки, будильники, другой звук"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7775,6 +7901,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Annulla"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отменить"
           }
         },
         "zh-Hans" : {
@@ -7825,6 +7957,12 @@
             "value" : "Annulla il download"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отменить загрузку"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7871,6 +8009,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Annulla timer di spegnimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отменить таймер сна"
           }
         },
         "zh-Hans" : {
@@ -7921,6 +8065,12 @@
             "value" : "Annulla tutti i timer di spegnimento"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отменяет активный таймер сна."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7965,6 +8115,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limita la dimensione totale dei download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ограничить общий размер загрузок"
           }
         },
         "zh-Hans" : {
@@ -8015,6 +8171,12 @@
             "value" : "Stile carta"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Стиль карточек"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8063,6 +8225,12 @@
             "value" : "Carte"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Карточки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8109,6 +8277,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Carosello"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Карусель"
           }
         },
         "zh-Hans" : {
@@ -8171,6 +8345,98 @@
         }
       }
     },
+    "Catch Up" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indhent"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aufholen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ponerse al día"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rattrapage"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recupero"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追上进度"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追上進度"
+          }
+        }
+      }
+    },
+    "Catch Up needs iOS 26 or later." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indhent kræver iOS 26 eller nyere."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aufholen erfordert iOS 26 oder neuer."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ponerse al día requiere iOS 26 o posterior."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rattrapage nécessite iOS 26 ou une version ultérieure."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recupero richiede iOS 26 o versioni successive."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追上进度需要 iOS 26 或更高版本。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追上進度需要 iOS 26 或以上版本。"
+          }
+        }
+      }
+    },
     "Chapter" : {
       "comment" : "A display name for a playback history action.",
       "isCommentAutoGenerated" : true,
@@ -8203,6 +8469,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Capitolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Глава"
           }
         },
         "zh-Hans" : {
@@ -8253,6 +8525,12 @@
             "value" : "Limite del capitolo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Барьер главы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8299,6 +8577,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "I tempi del capitolo si adattano alla velocità"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время главы пересчитывается с учётом скорости"
           }
         },
         "zh-Hans" : {
@@ -8349,6 +8633,12 @@
             "value" : "Il titolo del capitolo e la copertina sono gestiti da Visualizzazione riproduzione."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название главы и обложка настраиваются в разделе «Отображение воспроизведения»."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8395,6 +8685,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Capitoli"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Главы"
           }
         },
         "zh-Hans" : {
@@ -8493,6 +8789,12 @@
             "value" : "Interfaccia del player più pulita"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Более чистый интерфейс плеера"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8539,6 +8841,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancella"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить"
           }
         },
         "zh-Hans" : {
@@ -8589,6 +8897,12 @@
             "value" : "Cancella tutti i downloads"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить все загрузки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8635,6 +8949,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vuoi cancellare tutti i downloads ?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить все загрузки?"
           }
         },
         "zh-Hans" : {
@@ -8685,6 +9005,12 @@
             "value" : "Cancella tutta la chache immagini"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить кэш изображений"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8731,6 +9057,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vuoi cancellare tutta la cache immagini ?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить кэш изображений?"
           }
         },
         "zh-Hans" : {
@@ -8781,6 +9113,12 @@
             "value" : "Chiudi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрыть"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8827,6 +9165,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caffè"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кофе"
           }
         },
         "zh-Hans" : {
@@ -8877,6 +9221,12 @@
             "value" : "Comprimi serie"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сворачивать циклы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8923,6 +9273,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tipo di raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тип подборки"
           }
         },
         "zh-Hans" : {
@@ -8973,6 +9329,12 @@
             "value" : "Raccolte"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подборки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9019,6 +9381,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le raccolte sono condivise tra tutti gli utenti del server."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подборки общие для всех пользователей сервера."
           }
         },
         "zh-Hans" : {
@@ -9069,6 +9437,12 @@
             "value" : "Schema colori"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цветовая схема"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9115,6 +9489,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Colonne"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Столбцы"
           }
         },
         "zh-Hans" : {
@@ -9209,6 +9589,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройка"
           }
         },
         "zh-Hans" : {
@@ -9351,6 +9737,12 @@
             "value" : "Connesso"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подключено"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9445,6 +9837,12 @@
             "value" : "Errore di connessione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ошибка подключения"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9491,6 +9889,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Console"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Консоль"
           }
         },
         "zh-Hans" : {
@@ -9541,6 +9945,12 @@
             "value" : "Contenuto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Содержимое"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9587,6 +9997,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Contenuti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Содержание"
           }
         },
         "zh-Hans" : {
@@ -9637,6 +10053,12 @@
             "value" : "Continua libri"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить книги"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9683,6 +10105,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continua ad ascoltare"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить прослушивание"
           }
         },
         "zh-Hans" : {
@@ -9733,6 +10161,12 @@
             "value" : "Continua a leggere"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить чтение"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9779,6 +10213,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continua la serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить цикл"
           }
         },
         "zh-Hans" : {
@@ -9829,6 +10269,12 @@
             "value" : "Controlli e layout"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Элементы управления и компоновка"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9877,6 +10323,12 @@
             "value" : "Controlli, sospensione, salto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление, таймер сна, перемотка"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9923,6 +10375,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Raggio degli angoli"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Радиус скругления"
           }
         },
         "zh-Hans" : {
@@ -9983,6 +10441,98 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無法在有聲書中找到該頁。請嘗試文字較多的一頁，或更接近你目前收聽位置的一頁。"
+          }
+        }
+      }
+    },
+    "Couldn't find your reading position in %@. That part may not be narrated in this recording." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke finde din læseposition i %@. Den del er måske ikke indlæst i denne optagelse."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Leseposition konnte in %@ nicht gefunden werden. Dieser Teil ist in dieser Aufnahme möglicherweise nicht enthalten."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo encontrar tu posición de lectura en %@. Puede que esa parte no esté narrada en esta grabación."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de trouver votre position de lecture dans %@. Cette partie n'est peut-être pas narrée dans cet enregistrement."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non è stato possibile trovare la tua posizione di lettura in %@. Quella parte potrebbe non essere narrata in questa registrazione."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未能在%@中找到你的阅读位置。此录音中可能没有朗读这一部分。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未能在%@中找到你的閱讀位置。此錄音中可能沒有朗讀這一部分。"
+          }
+        }
+      }
+    },
+    "Couldn't find your reading position in the audiobook. It may not be narrated in this recording." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke finde din læseposition i lydbogen. Den er måske ikke indlæst i denne optagelse."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Leseposition konnte im Hörbuch nicht gefunden werden. Sie ist in dieser Aufnahme möglicherweise nicht enthalten."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo encontrar tu posición de lectura en el audiolibro. Puede que no esté narrada en esta grabación."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de trouver votre position de lecture dans le livre audio. Elle n'est peut-être pas narrée dans cet enregistrement."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non è stato possibile trovare la tua posizione di lettura nell'audiolibro. Potrebbe non essere narrata in questa registrazione."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未能在有声书中找到你的阅读位置。此录音中可能没有朗读这一部分。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未能在有聲書中找到你的閱讀位置。此錄音中可能沒有朗讀這一部分。"
           }
         }
       }
@@ -10067,6 +10617,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impossibile caricare altri elementi. Tocca per riprovare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить ещё. Нажмите, чтобы повторить."
           }
         },
         "zh-Hans" : {
@@ -10227,6 +10783,52 @@
         }
       }
     },
+    "Couldn't tell where you stopped reading. Open the ebook first." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke afgøre, hvor du stoppede med at læse. Åbn e-bogen først."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es ließ sich nicht feststellen, wo du aufgehört hast zu lesen. Öffne zuerst das E-Book."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo determinar dónde dejaste de leer. Abre primero el libro electrónico."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de déterminer où vous vous êtes arrêté de lire. Ouvrez d'abord l'ebook."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non è stato possibile capire dove hai smesso di leggere. Apri prima l'ebook."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法确定你的阅读位置。请先打开电子书。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法確定你的閱讀位置。請先開啟電子書。"
+          }
+        }
+      }
+    },
     "Cover art size and details for Continue Listening and Continue Reading. When off, the author is shown instead." : {
       "comment" : "A description of the \"Show Time Remaining\" toggle in the Home preferences view.",
       "isCommentAutoGenerated" : true,
@@ -10259,6 +10861,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dimensione e dettagli della copertina per Continua ad ascoltare e Continua a leggere. Quando disattivato, viene mostrato l'autore."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размер обложки и сведения для разделов «Продолжить прослушивание» и «Продолжить чтение». Если выключено, показывается автор."
           }
         },
         "zh-Hans" : {
@@ -10309,6 +10917,12 @@
             "value" : "Cover Flow"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Карусель обложек"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10355,6 +10969,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Crea"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать"
           }
         },
         "zh-Hans" : {
@@ -10405,6 +11025,12 @@
             "value" : "Crea una chiave API"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать API-ключ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10451,6 +11077,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Crea raccolte o playlist nell'app"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создайте подборки или плейлисты в приложении"
           }
         },
         "zh-Hans" : {
@@ -10501,6 +11133,12 @@
             "value" : "Crea qui il tuo primo segnalibro."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создайте первую закладку ниже."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10547,6 +11185,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Crea qui la tua prima raccolta."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создайте первую подборку ниже."
           }
         },
         "zh-Hans" : {
@@ -10597,6 +11241,12 @@
             "value" : "Crea qui la tua prima playlist."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создайте первый плейлист ниже."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10643,6 +11293,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Crea la tua prima playlist per iniziare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создайте первый плейлист, чтобы начать."
           }
         },
         "zh-Hans" : {
@@ -10693,6 +11349,12 @@
             "value" : "Credenziali"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Учётные данные"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10739,6 +11401,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Colore personalizzato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Свой цвет"
           }
         },
         "zh-Hans" : {
@@ -10789,6 +11457,12 @@
             "value" : "Intestazioni personalizzate"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Свои заголовки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10835,6 +11509,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gli header personalizzati verranno inviati con ogni richiesta al tuo server."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Свои заголовки будут отправляться с каждым запросом к вашему серверу."
           }
         },
         "zh-Hans" : {
@@ -10885,6 +11565,12 @@
             "value" : "Durata personalizzata"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Своё время"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10931,6 +11617,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OBIETTIVO GIORNALIERO"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ЦЕЛЬ НА ДЕНЬ"
           }
         },
         "zh-Hans" : {
@@ -10981,6 +11673,12 @@
             "value" : "Obiettivo giornaliero di ascolto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цель прослушивания на день"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11027,6 +11725,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scuro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тёмный"
           }
         },
         "zh-Hans" : {
@@ -11077,6 +11781,12 @@
             "value" : "Scurisci le copertine dei libri completati"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Затемнять обложки прослушанных книг"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11123,6 +11833,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Data di aggiunta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата добавления"
           }
         },
         "zh-Hans" : {
@@ -11173,6 +11889,12 @@
             "value" : "Giorno"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "День"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11219,6 +11941,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "giorni consecutivi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "дней подряд"
           }
         },
         "zh-Hans" : {
@@ -11269,6 +11997,12 @@
             "value" : "giorni"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "дней"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11315,6 +12049,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Debug"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отладка"
           }
         },
         "zh-Hans" : {
@@ -11365,6 +12105,12 @@
             "value" : "Predefinito"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "По умолчанию"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11411,6 +12157,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PREDEFINITO"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ПО УМОЛЧАНИЮ"
           }
         },
         "zh-Hans" : {
@@ -11461,6 +12213,12 @@
             "value" : "Durata predefinita"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Длительность по умолчанию"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11507,6 +12265,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Predefinito per nuovi libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "По умолчанию для новых книг"
           }
         },
         "zh-Hans" : {
@@ -11557,6 +12321,12 @@
             "value" : "Velocità di narrazione predefinita"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скорость чтения по умолчанию"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11603,6 +12373,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ritardo prima del download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задержка перед загрузкой"
           }
         },
         "zh-Hans" : {
@@ -11653,6 +12429,12 @@
             "value" : "Elimina"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11699,6 +12481,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elimina la raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить подборку"
           }
         },
         "zh-Hans" : {
@@ -11749,6 +12537,12 @@
             "value" : "Elimina la palylist"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить плейлист"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11795,6 +12589,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Descrizione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Описание"
           }
         },
         "zh-Hans" : {
@@ -11845,6 +12645,12 @@
             "value" : "Descrizione (facoltativa)"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Описание (необязательно)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11891,6 +12697,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Attenua i libri completati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Затемнять прослушанные книги"
           }
         },
         "zh-Hans" : {
@@ -11941,6 +12753,12 @@
             "value" : "Cena"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ужин"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11987,6 +12805,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "I controlli disattivati vengono spostati nel menu di overflow del lettore."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отключённые элементы перемещаются в дополнительное меню плеера."
           }
         },
         "zh-Hans" : {
@@ -12037,6 +12861,12 @@
             "value" : "Disconnetti"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет подключения"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12083,6 +12913,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scopri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обзор"
           }
         },
         "zh-Hans" : {
@@ -12133,6 +12969,12 @@
             "value" : "Porta per la ricerca automatica"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Порт для поиска"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12143,6 +12985,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "探索連接埠"
+          }
+        }
+      }
+    },
+    "Dismiss" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afvis"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ausblenden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descartar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignorer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignora"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉"
           }
         }
       }
@@ -12179,6 +13067,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scala di visualizzazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштаб интерфейса"
           }
         },
         "zh-Hans" : {
@@ -12229,6 +13123,12 @@
             "value" : "Mostra il sottotitolo del libro sotto il titolo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать подзаголовок книги под названием"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12275,6 +13175,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non riavvolgere oltre l'inizio del capitolo corrente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не откатываться за начало текущей главы"
           }
         },
         "zh-Hans" : {
@@ -12325,6 +13231,12 @@
             "value" : "Fine"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12371,6 +13283,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузить"
           }
         },
         "zh-Hans" : {
@@ -12421,6 +13339,12 @@
             "value" : "Scarica tutto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузить все"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12465,6 +13389,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scarica gli episodi aggiunti automaticamente alla coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загружать выпуски, автоматически добавленные в очередь"
           }
         },
         "zh-Hans" : {
@@ -12513,6 +13443,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sezione Download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вкладка загрузок"
           }
         },
         "zh-Hans" : {
@@ -12573,6 +13509,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "請先下載此有聲書。頁面比對需要在裝置上收聽音訊。"
+          }
+        }
+      }
+    },
+    "Download this audiobook to catch up." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hent denne lydbog for at indhente."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lade dieses Hörbuch herunter, um aufzuholen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descarga este audiolibro para ponerte al día."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargez ce livre audio pour rattraper votre lecture."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scarica questo audiolibro per recuperare."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请下载此有声书以追上进度。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請下載此有聲書以追上進度。"
           }
         }
       }
@@ -12673,6 +13655,52 @@
         }
       }
     },
+    "Download this book's ebook to catch up." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hent denne bogs e-bog for at indhente."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lade das E-Book zu diesem Buch herunter, um aufzuholen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descarga el libro electrónico de este libro para ponerte al día."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargez l'ebook de ce livre pour rattraper votre lecture."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scarica l'ebook di questo libro per recuperare."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请下载这本书的电子书以追上进度。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請下載這本書的電子書以追上進度。"
+          }
+        }
+      }
+    },
     "Download what you want and take it anywhere." : {
       "localizations" : {
         "da" : {
@@ -12751,6 +13779,12 @@
             "value" : "Scarica il seguito di serie e podcast iniziati"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загружать следующее в начатых циклах и подкастах"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12797,6 +13831,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scaricati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загружено"
           }
         },
         "zh-Hans" : {
@@ -12847,6 +13887,12 @@
             "value" : "Libri Scaricati"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загруженные книги"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12893,6 +13939,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "In download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загружается"
           }
         },
         "zh-Hans" : {
@@ -12943,6 +13995,12 @@
             "value" : "Downloads"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12989,6 +14047,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trascina la barra di avanzamento per saltare a una posizione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перетащите полосу прогресса, чтобы перейти к нужной позиции"
           }
         },
         "zh-Hans" : {
@@ -13039,6 +14103,12 @@
             "value" : "Trascina per riordinare. Appaiono direttamente nel lettore."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перетащите, чтобы изменить порядок. Эти элементы показываются прямо в плеере."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13085,6 +14155,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Durata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Длительность"
           }
         },
         "zh-Hans" : {
@@ -13135,6 +14211,12 @@
             "value" : "Durata del timer di sospensione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Длительность таймера сна"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13181,6 +14263,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La durata deve essere maggiore di 0 minuti."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Длительность должна быть больше 0 минут."
           }
         },
         "zh-Hans" : {
@@ -13231,6 +14319,12 @@
             "value" : "Durata del salto indietro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "На сколько отмотать назад"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13277,6 +14371,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Durata del salto in avanti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "На сколько отмотать вперёд"
           }
         },
         "zh-Hans" : {
@@ -13327,6 +14427,12 @@
             "value" : "Proporzioni dinamiche"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Динамические пропорции"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13370,6 +14476,12 @@
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E%@"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "E%@"
@@ -13423,6 +14535,12 @@
             "value" : "Ebook"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Электронная книга"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13469,6 +14587,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "eBooks"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Электронные книги"
           }
         },
         "zh-Hans" : {
@@ -13519,6 +14643,12 @@
             "value" : "Ebook"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Электронные книги"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13565,6 +14695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modifica"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изменить"
           }
         },
         "zh-Hans" : {
@@ -13615,6 +14751,12 @@
             "value" : "Modifica il Segnalibro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изменить закладку"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13661,6 +14803,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modifica la playlist"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изменить плейлист"
           }
         },
         "zh-Hans" : {
@@ -13711,6 +14859,12 @@
             "value" : "Entrambi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Любое"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13757,6 +14911,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Contatta il supporto via email"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Написать в поддержку"
           }
         },
         "zh-Hans" : {
@@ -13807,6 +14967,36 @@
             "value" : "Fine di %lld capitoli"
           }
         },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "После %lld глав"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "После %lld глав"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "После %lld главы"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "После %lld главы"
+                }
+              }
+            }
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13853,6 +15043,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fine del capitolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Конец главы"
           }
         },
         "zh-Hans" : {
@@ -13903,6 +15099,12 @@
             "value" : "Inserisci un'altro titolo per questo segnalibro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите новое название закладки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13951,6 +15153,12 @@
             "value" : "Digita il testo da cercare in questo libro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите текст для поиска по книге"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13997,6 +15205,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Inserisci il numero di porta da scansionare per trovare i server Audiobookshelf nella tua rete locale."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите номер порта для поиска серверов Audiobookshelf в локальной сети."
           }
         },
         "zh-Hans" : {
@@ -14093,6 +15307,12 @@
             "value" : "Episodi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выпуски"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14139,6 +15359,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Equalizzatore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Эквалайзер"
           }
         },
         "zh-Hans" : {
@@ -14189,6 +15415,12 @@
             "value" : "Uniforma i passaggi forti e deboli"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выравнивает громкие и тихие фрагменты"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14235,6 +15467,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Esempio: X-API-Key, Authorization, ecc."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Например: X-API-Key, Authorization и т. д."
           }
         },
         "zh-Hans" : {
@@ -14285,6 +15523,12 @@
             "value" : "Esplicito"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ненормативный контент"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14331,6 +15575,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prolunga di %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продлить на %@"
           }
         },
         "zh-Hans" : {
@@ -14381,6 +15631,12 @@
             "value" : "Estendi il timer oppure scuoti il telefono per continuare ad ascoltare."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продлите таймер или встряхните телефон, чтобы продолжить прослушивание."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14427,6 +15683,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Extra Large"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очень большой"
           }
         },
         "zh-Hans" : {
@@ -14477,6 +15739,12 @@
             "value" : "Caricamento non riuscito"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14523,6 +15791,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caricamento degli episodi non riuscito"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить выпуски"
           }
         },
         "zh-Hans" : {
@@ -14573,6 +15847,12 @@
             "value" : "Data di creazione del file"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата создания файла"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14619,6 +15899,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "File Modificato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата изменения файла"
           }
         },
         "zh-Hans" : {
@@ -14669,6 +15955,12 @@
             "value" : "Dimensione file"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размер файла"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14715,6 +16007,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filtra"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтр"
           }
         },
         "zh-Hans" : {
@@ -14765,6 +16063,12 @@
             "value" : "Filtra i libri"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтр книг"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14811,6 +16115,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filtra i downloads"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтр загрузок"
           }
         },
         "zh-Hans" : {
@@ -14861,6 +16171,12 @@
             "value" : "Filtra la libreria"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтр библиотеки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14907,6 +16223,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trova episodi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Найти выпуски"
           }
         },
         "zh-Hans" : {
@@ -14971,6 +16293,98 @@
         }
       }
     },
+    "Finding where the narrator is…" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finder, hvor oplæseren er…"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suche, wo der Sprecher gerade ist…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscando dónde va el narrador…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche de la position du narrateur…"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ricerca del punto in cui si trova il narratore…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在查找朗读者的位置…"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在尋找朗讀者的位置…"
+          }
+        }
+      }
+    },
+    "Finding where you stopped reading…" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finder, hvor du stoppede med at læse…"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suche, wo du aufgehört hast zu lesen…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscando dónde dejaste de leer…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche de l'endroit où vous vous êtes arrêté…"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ricerca del punto in cui hai smesso di leggere…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在查找你的阅读位置…"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在尋找你的閱讀位置…"
+          }
+        }
+      }
+    },
     "Finished" : {
       "comment" : "A label indicating that a media item has been fully watched.",
       "isCommentAutoGenerated" : true,
@@ -15003,6 +16417,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Terminato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прослушано"
           }
         },
         "zh-Hans" : {
@@ -15053,6 +16473,12 @@
             "value" : "Full Immersion"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фокусирование"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15099,6 +16525,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Funzioni Full Immersion"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Функции фокусирования"
           }
         },
         "zh-Hans" : {
@@ -15195,6 +16627,12 @@
             "value" : "Tipo di carattere"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Шрифт"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15241,6 +16679,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Grandezza del carattere"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размер шрифта"
           }
         },
         "zh-Hans" : {
@@ -15291,6 +16735,12 @@
             "value" : "Peso del carattere"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Насыщенность шрифта"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15301,6 +16751,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字體粗細"
+          }
+        }
+      }
+    },
+    "For Now" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indtil videre"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorerst"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por ahora"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pour l'instant"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Per ora"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂时隐藏"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫時隱藏"
           }
         }
       }
@@ -15337,6 +16833,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avanti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вперёд"
           }
         },
         "zh-Hans" : {
@@ -15387,6 +16889,12 @@
             "value" : "Base"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Основание"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15431,6 +16939,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Libera spazio al termine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Освобождать место после прослушивания"
           }
         },
         "zh-Hans" : {
@@ -15481,6 +16995,12 @@
             "value" : "Generali"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Основные"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15527,6 +17047,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Generi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жанры"
           }
         },
         "zh-Hans" : {
@@ -15577,6 +17103,12 @@
             "value" : "Dissolvenza graduale prima della sveglia"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Плавное затухание перед сигналом"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15623,6 +17155,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dissolvenza graduale prima dell'arresto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Плавное затухание перед остановкой"
           }
         },
         "zh-Hans" : {
@@ -15681,6 +17219,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在 AudioBooth Discord 取得協助"
+          }
+        }
+      }
+    },
+    "Getting ready… %lld%%" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gør klar… %lld %%"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird vorbereitet… %lld %%"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando… %lld %%"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation… %lld %%"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione… %lld %%"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备… %lld%%"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在準備… %lld%%"
           }
         }
       }
@@ -15765,6 +17349,12 @@
             "value" : "Obbiettivo raggiunto!"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цель достигнута!"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15811,6 +17401,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Obiettivo superato, ^[%lld min](inflect: true) in più"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цель по ежедневному прослушиванию превышена на %lld мин"
           }
         },
         "zh-Hans" : {
@@ -15861,6 +17457,12 @@
             "value" : "Verde"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зелёный"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15907,6 +17509,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vista a griglia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сетка"
           }
         },
         "zh-Hans" : {
@@ -15957,6 +17565,12 @@
             "value" : "Feedback aptico"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тактильный отклик"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16003,6 +17617,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dettagli dell'intestazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Параметры заголовка"
           }
         },
         "zh-Hans" : {
@@ -16053,6 +17673,12 @@
             "value" : "Nome dell’intestazione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя заголовка"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16099,6 +17725,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valore dell’intestazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Значение заголовка"
           }
         },
         "zh-Hans" : {
@@ -16149,6 +17781,12 @@
             "value" : "Aiuto & Feedback"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помощь и отзывы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16197,6 +17835,12 @@
             "value" : "Aiuta a sostenere AudioBooth"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поддержите развитие AudioBooth"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16242,6 +17886,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ciao, %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Привет, %@"
           }
         },
         "zh-Hans" : {
@@ -16292,6 +17942,12 @@
             "value" : "Nascondi i pulsanti per saltare i capitoli"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скрыть кнопки перехода по главам"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16302,6 +17958,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隱藏章節跳過按鈕"
+          }
+        }
+      }
+    },
+    "Hide this banner?" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skjul dette banner?"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieses Banner ausblenden?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Ocultar este aviso?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer cette bannière ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vuoi nascondere questo banner?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏此横幅？"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏此橫幅？"
           }
         }
       }
@@ -16338,6 +18040,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nascondi titolo e metadati sotto le copertine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скрывать название и метаданные под обложками"
           }
         },
         "zh-Hans" : {
@@ -16386,6 +18094,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Высокая"
           }
         },
         "zh-Hans" : {
@@ -16482,6 +18196,12 @@
             "value" : "Storico"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "История"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16575,6 +18295,12 @@
             "value" : "Tieni premuto per sbloccare"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удерживайте, чтобы разблокировать"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16621,6 +18347,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Principale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Главная"
           }
         },
         "zh-Hans" : {
@@ -16671,6 +18403,12 @@
             "value" : "ora"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "час"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16717,6 +18455,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "часов"
           }
         },
         "zh-Hans" : {
@@ -16767,6 +18511,12 @@
             "value" : "Ore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Часы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16813,6 +18563,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "h"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ч"
           }
         },
         "zh-Hans" : {
@@ -16909,6 +18665,12 @@
             "value" : "iCloud"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16955,6 +18717,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sincronizzazione iCloud"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация с iCloud"
           }
         },
         "zh-Hans" : {
@@ -17005,6 +18773,12 @@
             "value" : "Cache immagini"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кэш изображений"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17051,6 +18825,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Copertina immersiva"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обложка во весь экран"
           }
         },
         "zh-Hans" : {
@@ -17101,6 +18881,12 @@
             "value" : "Dopo una durata"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Через"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17147,6 +18933,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nel menu overflow"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В дополнительном меню"
           }
         },
         "zh-Hans" : {
@@ -17197,6 +18989,12 @@
             "value" : "Nella barra del lettore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В панели плеера"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17245,6 +19043,12 @@
             "value" : "Includi le credenziali"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предоставить учётные данные"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17291,6 +19095,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "App indie. Sostenuta dai supporter."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Инди-приложение. Живёт благодаря поддержке."
           }
         },
         "zh-Hans" : {
@@ -17387,6 +19197,12 @@
             "value" : "Isaac Asimov"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Айзек Азимов"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17481,6 +19297,12 @@
             "value" : "Gli elementi già completati vengono saltati. Quando non c'è più nulla da riprodurre, il player si chiude."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прослушанные элементы пропускаются. Если очередь воспроизведения пуста, плеер закрывается."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17529,6 +19351,12 @@
             "value" : "Unisciti al nostro Discord"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Присоединяйтесь к нашему Discord"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17573,6 +19401,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mantieni i prossimi elementi offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранить следующие элементы"
           }
         },
         "zh-Hans" : {
@@ -17623,6 +19457,12 @@
             "value" : "Mantieni lo schermo acceso"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не выключать экран"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17669,6 +19509,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Orizzontale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Горизонтально"
           }
         },
         "zh-Hans" : {
@@ -17719,6 +19565,12 @@
             "value" : "Lingue"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Языки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17765,6 +19617,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Grande"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Большой"
           }
         },
         "zh-Hans" : {
@@ -17815,6 +19673,36 @@
             "value" : "Ultime %lld settimane"
           }
         },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Последние %lld недели"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Последних %lld недель"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Последняя %lld неделя"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Последние %lld недели"
+                }
+              }
+            }
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17861,6 +19749,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ultimi 7 giorni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 7 дней"
           }
         },
         "zh-Hans" : {
@@ -17911,6 +19805,12 @@
             "value" : "Ultimi 14 giorni"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 14 дней"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17957,6 +19857,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ultime 24 ore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 24 часа"
           }
         },
         "zh-Hans" : {
@@ -18007,6 +19913,12 @@
             "value" : "Ultimi 30 giorni"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 30 дней"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18053,6 +19965,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ultimo aggiornamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последнее обновление"
           }
         },
         "zh-Hans" : {
@@ -18103,6 +20021,12 @@
             "value" : "Novità"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Новое"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18149,6 +20073,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Episodio più recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последний выпуск"
           }
         },
         "zh-Hans" : {
@@ -18199,6 +20129,12 @@
             "value" : "Avvio, feedback aptico, aspetto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запуск, тактильный отклик, оформление"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18245,6 +20181,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Layout"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Компоновка"
           }
         },
         "zh-Hans" : {
@@ -18295,6 +20237,12 @@
             "value" : "Layout, proporzioni e raggio degli angoli"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Компоновка, пропорции и скругление углов"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18341,6 +20289,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Legal"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Правовая информация"
           }
         },
         "zh-Hans" : {
@@ -18391,6 +20345,12 @@
             "value" : "Meno"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Меньше"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18437,6 +20397,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Spaziatura carattere"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Межбуквенный интервал"
           }
         },
         "zh-Hans" : {
@@ -18487,6 +20453,12 @@
             "value" : "Librerie"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Библиотеки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18533,6 +20505,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Libreria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Библиотека"
           }
         },
         "zh-Hans" : {
@@ -18583,6 +20561,12 @@
             "value" : "Tipo di libreria"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тип библиотеки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18629,6 +20613,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chiaro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Светлый"
           }
         },
         "zh-Hans" : {
@@ -18679,6 +20669,12 @@
             "value" : "Varianti chiaro · scuro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Светлый · тёмный"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18723,6 +20719,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limiti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ограничения"
           }
         },
         "zh-Hans" : {
@@ -18773,6 +20775,12 @@
             "value" : "Altezza interlinea"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Высота строки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18821,6 +20829,12 @@
             "value" : "Visualizzazione elenco"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Список"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18867,6 +20881,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ascolta Dinuovo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прослушать снова"
           }
         },
         "zh-Hans" : {
@@ -18963,6 +20983,12 @@
             "value" : "ASCOLTATO"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ПРОСЛУШАНО"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19021,6 +21047,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在收聽 %@ 附近…"
+          }
+        }
+      }
+    },
+    "Listening for the last words you read. This can take a minute." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lytter efter de sidste ord, du læste. Det kan tage et minut."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es wird nach den letzten Wörtern gesucht, die du gelesen hast. Das kann einen Moment dauern."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscando las últimas palabras que leíste. Esto puede tardar un minuto."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche des derniers mots que vous avez lus. Cela peut prendre une minute."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ricerca delle ultime parole che hai letto. Può richiedere un minuto."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在聆听你最后读到的内容。这可能需要一分钟。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在聆聽你最後讀到的內容。這可能需要一分鐘。"
           }
         }
       }
@@ -19153,6 +21225,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Statistiche di ascolto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статистика прослушивания"
           }
         },
         "zh-Hans" : {
@@ -19345,6 +21423,12 @@
             "value" : "Carica altro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузить ещё"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19391,6 +21475,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caricamento dettagli autore..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка сведений об авторе..."
           }
         },
         "zh-Hans" : {
@@ -19441,6 +21531,12 @@
             "value" : "Caricamento autori..."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка авторов..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19487,6 +21583,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caricamento dettagli libro..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка сведений о книге..."
           }
         },
         "zh-Hans" : {
@@ -19537,6 +21639,12 @@
             "value" : "Caricamento libri..."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка книг..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19583,6 +21691,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caricamento delle raccolte..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка подборок..."
           }
         },
         "zh-Hans" : {
@@ -19633,6 +21747,12 @@
             "value" : "Caricamento downloads…"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка списка..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19679,6 +21799,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caricamento ebook..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка книги..."
           }
         },
         "zh-Hans" : {
@@ -19729,6 +21855,12 @@
             "value" : "Caricamento episodi…"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка выпусков..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19775,6 +21907,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caricamento episodi..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка выпусков..."
           }
         },
         "zh-Hans" : {
@@ -19825,6 +21963,12 @@
             "value" : "Caricamento librerie..."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка библиотек..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19871,6 +22015,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caricamento narratori..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка дикторов..."
           }
         },
         "zh-Hans" : {
@@ -19921,6 +22071,12 @@
             "value" : "Caricamento playlists..."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка плейлистов..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19967,6 +22123,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caricamento dettagli podcast…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка сведений о подкасте..."
           }
         },
         "zh-Hans" : {
@@ -20017,6 +22179,12 @@
             "value" : "Caricamento Podcasts..."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка подкастов..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20063,6 +22231,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caricamento serie..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка циклов..."
           }
         },
         "zh-Hans" : {
@@ -20113,6 +22287,12 @@
             "value" : "Caricamento..."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20158,6 +22338,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blocca"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Блокировка"
           }
         },
         "zh-Hans" : {
@@ -20208,6 +22394,12 @@
             "value" : "Blocca orientamento del lettore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Заблокировать ориентацию плеера"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20254,6 +22446,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermata di blocco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Экран блокировки"
           }
         },
         "zh-Hans" : {
@@ -20304,6 +22502,12 @@
             "value" : "Accesso in corso..."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вход..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20350,6 +22554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La disconnessione rimuoverà tutti i download di questa connessione."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "При отключении все загрузки с этого сервера будут удалены."
           }
         },
         "zh-Hans" : {
@@ -20400,6 +22610,12 @@
             "value" : "Accedi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Войти"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20448,6 +22664,12 @@
             "value" : "Accedi con SSO"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Войти через SSO"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20494,6 +22716,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Esci"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выйти"
           }
         },
         "zh-Hans" : {
@@ -20592,6 +22820,12 @@
             "value" : "Basso"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Низкая"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20640,6 +22874,12 @@
             "value" : "Pranzo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обед"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20684,6 +22924,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gestisci"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление"
           }
         },
         "zh-Hans" : {
@@ -20734,6 +22980,12 @@
             "value" : "Gestisci download e cache"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление загрузками и кэшем"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20780,6 +23032,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gestisci server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление серверами"
           }
         },
         "zh-Hans" : {
@@ -20830,6 +23088,12 @@
             "value" : "Segna tutti come completati"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отметить все как прослушанные"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20876,6 +23140,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Segna come completato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отметить как прослушанное"
           }
         },
         "zh-Hans" : {
@@ -20926,6 +23196,12 @@
             "value" : "Segna come completato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отметить прослушанным"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20970,6 +23246,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Segna selezionati come completati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отметить выбранные как прослушанные"
           }
         },
         "zh-Hans" : {
@@ -21020,6 +23302,12 @@
             "value" : "Riavvolgimento massimo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимальный откат"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21066,6 +23354,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Spazio massimo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимальный объём хранилища"
           }
         },
         "zh-Hans" : {
@@ -21116,6 +23410,12 @@
             "value" : "Medio"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Средний"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21162,6 +23462,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Metadata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метаданные"
           }
         },
         "zh-Hans" : {
@@ -21212,6 +23518,12 @@
             "value" : "Metodo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Способ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21258,6 +23570,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "min"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "мин"
           }
         },
         "zh-Hans" : {
@@ -21308,6 +23626,12 @@
             "value" : "min/giorno"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "мин/день"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21354,6 +23678,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimizza"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Свернуть"
           }
         },
         "zh-Hans" : {
@@ -21404,6 +23734,12 @@
             "value" : "Minimale"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Компактный"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21450,6 +23786,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modalità minimale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Компактный режим"
           }
         },
         "zh-Hans" : {
@@ -21500,6 +23842,12 @@
             "value" : "Riavvolgimento minimo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Минимальный откат"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21546,6 +23894,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "minuti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "мин"
           }
         },
         "zh-Hans" : {
@@ -21596,6 +23950,12 @@
             "value" : "Minuti"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Минуты"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21644,6 +24004,12 @@
             "value" : "Minuti di ascolto (ultimi 7 giorni)"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Минут прослушивания (последние 7 дней)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21689,6 +24055,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Combina con altro audio"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Смешивать с другим звуком"
           }
         },
         "zh-Hans" : {
@@ -21739,6 +24111,12 @@
             "value" : "Modalità"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Режим"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21785,6 +24163,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Altro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ещё"
           }
         },
         "zh-Hans" : {
@@ -21835,6 +24219,12 @@
             "value" : "Più ascoltati"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Больше всего прослушано"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21881,6 +24271,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nome"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название"
           }
         },
         "zh-Hans" : {
@@ -21931,6 +24327,12 @@
             "value" : "Velocità narrazione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скорость чтения"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21977,6 +24379,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Narratori"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дикторы"
           }
         },
         "zh-Hans" : {
@@ -22027,6 +24435,12 @@
             "value" : "Ricerca in rete locale"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск в сети"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22073,6 +24487,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mai"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Никогда"
           }
         },
         "zh-Hans" : {
@@ -22123,6 +24543,12 @@
             "value" : "Nome dell nuova raccolta"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название новой подборки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22169,6 +24595,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nome della nuova playlist"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название нового плейлиста"
           }
         },
         "zh-Hans" : {
@@ -22219,6 +24651,12 @@
             "value" : "Autori più recenti"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Новые авторы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22265,6 +24703,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Episodi recenti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Новые выпуски"
           }
         },
         "zh-Hans" : {
@@ -22315,6 +24759,12 @@
             "value" : "Libro successivo della serie"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Следующая книга в цикле"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22361,6 +24811,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prossimo capitolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Следующая глава"
           }
         },
         "zh-Hans" : {
@@ -22411,6 +24867,12 @@
             "value" : "Prossimo capitolo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Следующая глава"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22457,6 +24919,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Libro scaricato successivo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Следующая загруженная книга"
           }
         },
         "zh-Hans" : {
@@ -22507,6 +24975,12 @@
             "value" : "Episodio di podcast successivo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Следующий выпуск подкаста"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22550,6 +25024,12 @@
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NFC"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NFC"
@@ -22603,6 +25083,12 @@
             "value" : "Scrittura Tag NFC"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запись NFC-метки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22649,6 +25135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non c’è alcun timer di spegnimento attivo da annullare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет активного таймера сна для отмены."
           }
         },
         "zh-Hans" : {
@@ -22699,6 +25191,12 @@
             "value" : "Non è in riproduzione alcun audiolibro."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "На данный момент ни одна аудиокнига не воспроизводится."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22745,6 +25243,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessun autore trovato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Авторы не найдены"
           }
         },
         "zh-Hans" : {
@@ -22795,6 +25299,12 @@
             "value" : "Nessun segnalibro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет закладок"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22841,6 +25351,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessun Libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет книг"
           }
         },
         "zh-Hans" : {
@@ -22891,6 +25407,12 @@
             "value" : "Nessun libro trovato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книги не найдены"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22937,6 +25459,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessun libro corrisponde alla tua ricerca."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет книг, соответствующих запросу."
           }
         },
         "zh-Hans" : {
@@ -22987,6 +25515,12 @@
             "value" : "Nessuna raccolta"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет подборок"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23033,6 +25567,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessuna raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет подборок"
           }
         },
         "zh-Hans" : {
@@ -23083,6 +25623,12 @@
             "value" : "Nessuna raccolta disponibile."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подборки недоступны."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23129,6 +25675,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessun contenuto disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступного контента"
           }
         },
         "zh-Hans" : {
@@ -23179,6 +25731,12 @@
             "value" : "Ancora nessun dato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пока нет данных"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23225,6 +25783,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessun downloads"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет загрузок"
           }
         },
         "zh-Hans" : {
@@ -23275,6 +25839,12 @@
             "value" : "Nessun pisodio"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет выпусков"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23321,6 +25891,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessuna dissolvenza"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Без затухания"
           }
         },
         "zh-Hans" : {
@@ -23371,6 +25947,12 @@
             "value" : "Nessuna cronologia"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет истории"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23417,6 +25999,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessun elemento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет элементов"
           }
         },
         "zh-Hans" : {
@@ -23467,6 +26055,12 @@
             "value" : "Nessun risultato trovato per '%@'"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ничего не найдено по запросу «%@»"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23513,6 +26107,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessun narratore trovato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дикторы не найдены"
           }
         },
         "zh-Hans" : {
@@ -23563,6 +26163,12 @@
             "value" : "Nessun contenuto offline"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет скаченного-контента"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23609,6 +26215,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessuna playlist"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет плейлистов"
           }
         },
         "zh-Hans" : {
@@ -23659,6 +26271,12 @@
             "value" : "Nessuna playlist"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет подкастов"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23705,6 +26323,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessun episodio recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет недавних выпусков"
           }
         },
         "zh-Hans" : {
@@ -23755,6 +26379,12 @@
             "value" : "Nessun risultato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет результатов"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23803,6 +26433,12 @@
             "value" : "Nessun risultato trovato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ничего не найдено"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23849,6 +26485,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessuna serie trovata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Циклы не найдены"
           }
         },
         "zh-Hans" : {
@@ -23945,6 +26587,12 @@
             "value" : "Nessun server connesso"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет подключённых серверов"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23991,6 +26639,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non selezionato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет"
           }
         },
         "zh-Hans" : {
@@ -24089,6 +26743,12 @@
             "value" : "Non ci sono abbastanza capitoli rimanenti. Il massimo è %lld."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недостаточно оставшихся глав. Максимум — %lld."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24135,6 +26795,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non impostato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не задана"
           }
         },
         "zh-Hans" : {
@@ -24233,6 +26899,12 @@
             "value" : "In riproduzione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сейчас играет"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24279,6 +26951,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "IN RIPRODUZIONE"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "СЕЙЧАС ИГРАЕТ"
           }
         },
         "zh-Hans" : {
@@ -24329,6 +27007,12 @@
             "value" : "Numero di capitoli (0 = capitolo corrente)"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Количество глав (0 — текущая глава)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24373,6 +27057,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Numero di elementi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Количество элементов"
           }
         },
         "zh-Hans" : {
@@ -24470,6 +27160,12 @@
             "value" : "Spegni"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выкл."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24480,6 +27176,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "關閉"
+          }
+        }
+      }
+    },
+    "Offer to Catch Up" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tilbyd at indhente"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aufholen vorschlagen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ofrecer ponerse al día"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proposer le rattrapage"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proponi il recupero"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示追上进度"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示追上進度"
           }
         }
       }
@@ -24515,6 +27257,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не в сети"
           }
         },
         "zh-Hans" : {
@@ -24560,6 +27308,12 @@
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OIDC (SSO)"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OIDC (SSO)"
@@ -24619,6 +27373,12 @@
             "value" : "Attivo – da %lld s a %lld s in base alla pausa"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вкл. — от %1$lld с до %2$lld с в зависимости от длины паузы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24665,6 +27425,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "All'interruzione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "При прерывании"
           }
         },
         "zh-Hans" : {
@@ -24715,6 +27481,12 @@
             "value" : "MANCIA UNICA"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "РАЗОВАЯ ПОДДЕРЖКА"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24761,6 +27533,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riavvolge solo se in pausa per %@+"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Откат только при паузе от %@"
           }
         },
         "zh-Hans" : {
@@ -24811,6 +27589,12 @@
             "value" : "Apri App Store"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть App Store"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24859,6 +27643,12 @@
             "value" : "Apri libro in…"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть книгу в…"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24905,6 +27695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Apri il player all'avvio"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открывать плеер при запуске"
           }
         },
         "zh-Hans" : {
@@ -25003,6 +27799,12 @@
             "value" : "Arancione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оранжевый"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25051,6 +27853,12 @@
             "value" : "Orientamento"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ориентация"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25097,6 +27905,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Margini pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поля страницы"
           }
         },
         "zh-Hans" : {
@@ -25243,6 +28057,12 @@
             "value" : "Indentazione paragrafi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отступ абзаца"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25289,6 +28109,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Spaziatura paragrafo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Интервал между абзацами"
           }
         },
         "zh-Hans" : {
@@ -25339,6 +28165,12 @@
             "value" : "Password"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пароль"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25385,6 +28217,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pausa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пауза"
           }
         },
         "zh-Hans" : {
@@ -25435,6 +28273,12 @@
             "value" : "Pausa riproduzione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Приостановить воспроизведение"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25481,6 +28325,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "In pausa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Приостановлено"
           }
         },
         "zh-Hans" : {
@@ -25531,6 +28381,12 @@
             "value" : "Pausa a %@"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пауза в %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25577,6 +28433,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mettendo in pausa la riproduzione, lo sleep-timer si spegne."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "При остановке воспроизведения таймер сна отключается."
           }
         },
         "zh-Hans" : {
@@ -25675,6 +28537,12 @@
             "value" : "Rosa"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Розовый"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25721,6 +28589,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Playlist in evidenza"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закреплённый плейлист"
           }
         },
         "zh-Hans" : {
@@ -25771,6 +28645,12 @@
             "value" : "Riproduci"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Воспроизвести"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25817,6 +28697,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riproduci tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Воспроизвести все"
           }
         },
         "zh-Hans" : {
@@ -25866,6 +28752,12 @@
             "value" : "Riproduci insieme alla musica di altre app"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Воспроизводить вместе с музыкой из других приложений"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25912,6 +28804,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riproduci audiolibro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Воспроизвести аудиокнигу"
           }
         },
         "zh-Hans" : {
@@ -26008,6 +28906,12 @@
             "value" : "Riproduci selezionati"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Воспроизвести выбранные"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26054,6 +28958,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riproduci l'elemento successivo in coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Воспроизводить следующий элемент из очереди"
           }
         },
         "zh-Hans" : {
@@ -26152,6 +29062,12 @@
             "value" : "Riproduzione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Воспроизведение"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26198,6 +29114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermata di riproduzione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отображение воспроизведения"
           }
         },
         "zh-Hans" : {
@@ -26248,6 +29170,12 @@
             "value" : "La riproduzione è già attiva."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Воспроизведение уже активно."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26294,6 +29222,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La riproduzione è già in pausa."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Воспроизведение уже приостановлено."
           }
         },
         "zh-Hans" : {
@@ -26344,6 +29278,12 @@
             "value" : "Comportamento in pausa"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поведение при паузе"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26390,6 +29330,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sessioni di Riproduzione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сеансы воспроизведения"
           }
         },
         "zh-Hans" : {
@@ -26440,6 +29386,12 @@
             "value" : "Riprodotto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прослушано"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26488,6 +29440,12 @@
             "value" : "Player"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Плеер"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26533,6 +29491,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Player bloccato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Плеер заблокирован"
           }
         },
         "zh-Hans" : {
@@ -26583,6 +29547,12 @@
             "value" : "Impostazioni del player"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки плеера"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26629,6 +29599,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nome playlist"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название плейлиста"
           }
         },
         "zh-Hans" : {
@@ -26679,6 +29655,12 @@
             "value" : "Playlists"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Плейлисты"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26725,6 +29707,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le playlist sono private. Solo l'utente che le crea può vederle."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Индивидуальные плейлисты видит только создавший их пользователь."
           }
         },
         "zh-Hans" : {
@@ -26775,6 +29763,12 @@
             "value" : "Dettagli podcast"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сведения о подкасте"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26821,6 +29815,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Podcasts"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подкасты"
           }
         },
         "zh-Hans" : {
@@ -27011,6 +30011,12 @@
             "value" : "Verticale"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вертикально"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27059,6 +30065,12 @@
             "value" : "Preamplificatore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предусилитель"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27105,6 +30117,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Preferenze"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки"
           }
         },
         "zh-Hans" : {
@@ -27251,6 +30269,12 @@
             "value" : "Presets"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предустановки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27297,6 +30321,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impedisci il blocco automatico mentre il player è aperto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не блокировать экран, пока открыт плеер"
           }
         },
         "zh-Hans" : {
@@ -27347,6 +30377,12 @@
             "value" : "Anteprima"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предпросмотр"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27393,6 +30429,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Capitolo precedente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предыдущая глава"
           }
         },
         "zh-Hans" : {
@@ -27443,6 +30485,12 @@
             "value" : "Capitolo precedente"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предыдущая глава"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27489,6 +30537,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Principale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Основной"
           }
         },
         "zh-Hans" : {
@@ -27539,6 +30593,12 @@
             "value" : "Privacy Policy"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Политика конфиденциальности"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27585,6 +30645,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Progresso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс"
           }
         },
         "zh-Hans" : {
@@ -27635,6 +30701,12 @@
             "value" : "Progresso: Terminato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс: прослушано"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27681,6 +30753,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Progresso: Ultimo Aggiornamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс: последнее обновление"
           }
         },
         "zh-Hans" : {
@@ -27731,6 +30809,12 @@
             "value" : "Progresso: avviato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс: начато"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27777,6 +30861,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Protocollo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Протокол"
           }
         },
         "zh-Hans" : {
@@ -27827,6 +30917,12 @@
             "value" : "Decennio di pubblicazione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Десятилетия издания"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27873,6 +30969,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Anno di pubblicazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Год издания"
           }
         },
         "zh-Hans" : {
@@ -27923,6 +31025,12 @@
             "value" : "Stili dell'editore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Стили издателя"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27971,6 +31079,12 @@
             "value" : "Editori"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Издатели"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28015,6 +31129,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scarica automaticamente i nuovi libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически загружать новые книги"
           }
         },
         "zh-Hans" : {
@@ -28062,6 +31182,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Puro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чистый"
           }
         },
         "zh-Hans" : {
@@ -28112,6 +31238,12 @@
             "value" : "Viola"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фиолетовый"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28158,6 +31290,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очередь"
           }
         },
         "zh-Hans" : {
@@ -28208,6 +31346,12 @@
             "value" : "Coda e continuazione intelligente"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очередь и умное продолжение"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28254,6 +31398,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La coda è vuota"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очередь пуста"
           }
         },
         "zh-Hans" : {
@@ -28304,6 +31454,12 @@
             "value" : "Random"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Случайно"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28352,6 +31508,12 @@
             "value" : "Ri-autentica"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пройти аутентификацию снова"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28396,6 +31558,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riscarica in qualsiasi momento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Можно загрузить снова в любое время"
           }
         },
         "zh-Hans" : {
@@ -28446,6 +31614,12 @@
             "value" : "Letto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Читать"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28492,6 +31666,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Leggi dinuovo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прочитать снова"
           }
         },
         "zh-Hans" : {
@@ -28920,6 +32100,12 @@
             "value" : "Impostazioni del lettore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки читалки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29062,6 +32248,12 @@
             "value" : "Gli episodi recenti dei podcast appariranno qui."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Здесь появятся недавние выпуски подкастов."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29108,6 +32300,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Serie Recenti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавние циклы"
           }
         },
         "zh-Hans" : {
@@ -29158,6 +32356,12 @@
             "value" : "Sessioni recenti"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавние сеансы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29204,6 +32408,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sessioni Recenti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавно добавленное"
           }
         },
         "zh-Hans" : {
@@ -29254,6 +32464,12 @@
             "value" : "Rosso"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Красный"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29298,6 +32514,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rimuovi al termine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалять после прослушивания"
           }
         },
         "zh-Hans" : {
@@ -29348,6 +32570,12 @@
             "value" : "Rimuovi dopo essere rimasti inutilizzati per"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалять после простоя"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29394,6 +32622,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rimuovi Completato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалять завершённые"
           }
         },
         "zh-Hans" : {
@@ -29444,6 +32678,12 @@
             "value" : "Rimuovi Download"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить загрузку"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29490,6 +32730,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rimuovi i downloads"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить загрузки"
           }
         },
         "zh-Hans" : {
@@ -29540,6 +32786,12 @@
             "value" : "Rimuovi da continua ad ascoltare"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Убрать из «Продолжить прослушивание»"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29586,6 +32838,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rimuovi dalla coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Убрать из очереди"
           }
         },
         "zh-Hans" : {
@@ -29636,6 +32894,12 @@
             "value" : "Rimuovi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переименовать"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29682,6 +32946,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ripeti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повтор"
           }
         },
         "zh-Hans" : {
@@ -29732,6 +33002,12 @@
             "value" : "Ripeti tutto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторять все"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29778,6 +33054,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ripeti capitolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторять главу"
           }
         },
         "zh-Hans" : {
@@ -29828,6 +33110,12 @@
             "value" : "Ripristina"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29874,6 +33162,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ripristina tutti i progressi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить весь прогресс"
           }
         },
         "zh-Hans" : {
@@ -29924,6 +33218,12 @@
             "value" : "Ripristina aspetto predefinito"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить настройки формления (по умолчанию)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29970,6 +33270,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ripristina ordine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить порядок"
           }
         },
         "zh-Hans" : {
@@ -30020,6 +33326,12 @@
             "value" : "Resetta i progressi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить прогресс"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30064,6 +33376,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ripristina i progressi selezionati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить прогресс выбранных"
           }
         },
         "zh-Hans" : {
@@ -30114,6 +33432,12 @@
             "value" : "Resetta il timer"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить таймер"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30160,6 +33484,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riprendi la riproduzione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить воспроизведение"
           }
         },
         "zh-Hans" : {
@@ -30210,6 +33540,12 @@
             "value" : "Riavvolgi di %llds all'inizio di una nuova sessione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Откатываться на %lld с при начале нового сеанса"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30256,6 +33592,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riavvolge poco dopo brevi pause e di più dopo pause lunghe, in base a quanto sei stato via."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Небольшой откат после короткой паузы и больший после длинной — в зависимости от того, сколько вас не было."
           }
         },
         "zh-Hans" : {
@@ -30306,6 +33648,12 @@
             "value" : "Riavvolgi dopo pausa di"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Откат после паузы длиной"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30354,6 +33702,12 @@
             "value" : "Riavvolgi all'inizio della sessione"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Откат при начале сеанса"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30400,6 +33754,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Intervallo riavvolgimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Диапазон отката"
           }
         },
         "zh-Hans" : {
@@ -30456,6 +33816,12 @@
             "value" : "S%1$@E%2$@"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S%1$@E%2$@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30504,6 +33870,12 @@
             "value" : "Salva"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранить"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30550,6 +33922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scansiona"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканировать"
           }
         },
         "zh-Hans" : {
@@ -30648,6 +34026,12 @@
             "value" : "Scansiona reti locali"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканировать локальную сеть"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30744,6 +34128,12 @@
             "value" : "Scansione della rete in corso..."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканирование сети..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30790,6 +34180,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modalità di scorrimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Режим прокрутки"
           }
         },
         "zh-Hans" : {
@@ -30840,6 +34236,12 @@
             "value" : "Cerca"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30886,6 +34288,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cerca libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск по книге"
           }
         },
         "zh-Hans" : {
@@ -30936,6 +34344,12 @@
             "value" : "Cerca episodi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск выпусков"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30982,6 +34396,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cerca libri, serie, autori, narratori, tag o generi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск книг, циклов, авторов, дикторов, тегов или жанров"
           }
         },
         "zh-Hans" : {
@@ -31032,6 +34452,12 @@
             "value" : "Cerca podcast o episodi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск подкастов или выпусков"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31078,6 +34504,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ricerca..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск..."
           }
         },
         "zh-Hans" : {
@@ -31128,6 +34560,12 @@
             "value" : "Secondi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Секунды"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31174,6 +34612,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sezioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Раздел"
           }
         },
         "zh-Hans" : {
@@ -31224,6 +34668,12 @@
             "value" : "Sezioni"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разделы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31270,6 +34720,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sezioni e ordine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разделы и порядок"
           }
         },
         "zh-Hans" : {
@@ -31320,6 +34776,12 @@
             "value" : "Ricerca"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемотка"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31366,6 +34828,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seleziona"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать"
           }
         },
         "zh-Hans" : {
@@ -31416,6 +34884,12 @@
             "value" : "Seleziona un libro per continuare"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите книгу, чтобы начать"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31464,6 +34938,12 @@
             "value" : "Seleziona tutto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать все"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31509,6 +34989,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seleziona elementi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите элементы"
           }
         },
         "zh-Hans" : {
@@ -31559,6 +35045,12 @@
             "value" : "Invia l'ebook a"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправить книгу в"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31605,6 +35097,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sensibilità: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чувствительность: %@"
           }
         },
         "zh-Hans" : {
@@ -31655,6 +35153,12 @@
             "value" : "Seppia"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сепия"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31701,6 +35205,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Циклы"
           }
         },
         "zh-Hans" : {
@@ -31751,6 +35261,12 @@
             "value" : "Server"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сервер"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31797,6 +35313,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configurazione del server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройка сервера"
           }
         },
         "zh-Hans" : {
@@ -31847,6 +35369,12 @@
             "value" : "Dettagli del server"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сведения о сервере"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31895,6 +35423,12 @@
             "value" : "Server URL"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL сервера"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31940,6 +35474,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Versione del server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версия сервера"
           }
         },
         "zh-Hans" : {
@@ -31996,6 +35536,12 @@
             "value" : "Server: %1$@, %2$@"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сервер: %1$@, %2$@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32042,6 +35588,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серверы"
           }
         },
         "zh-Hans" : {
@@ -32092,6 +35644,12 @@
             "value" : "Sessioni"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сеансы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32138,6 +35696,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Imposta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задать"
           }
         },
         "zh-Hans" : {
@@ -32188,6 +35752,12 @@
             "value" : "Imposta timer di spegnimento"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Установить таймер сна"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32234,6 +35804,12 @@
             "value" : "Imposta timer di spegnimento per ${duration}"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Установить таймер сна на ${duration}"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32278,6 +35854,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Imposta timer di spegnimento alla fine di ${chapters} capitoli"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Установить таймер сна до конца ${chapters} глав"
           }
         },
         "zh-Hans" : {
@@ -32328,6 +35910,12 @@
             "value" : "Imposta il timer di spegnimento alla fine del capitolo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Установить таймер сна до конца главы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32374,6 +35962,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Imposta timer di spegnimento con durata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Установить таймер сна с длительностью"
           }
         },
         "zh-Hans" : {
@@ -32470,6 +36064,12 @@
             "value" : "Imposta il timer di spegnimento per mettere in pausa dopo una durata specificata."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ставит воспроизведение на паузу по истечении заданного времени."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32516,6 +36116,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Imposta il timer di spegnimento per mettere in pausa alla fine di un numero specificato di capitoli."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ставит воспроизведение на паузу в конце заданного числа глав."
           }
         },
         "zh-Hans" : {
@@ -32566,6 +36172,12 @@
             "value" : "Impostazioni"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32612,6 +36224,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sensibilità allo scuotimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чувствительность встряхивания"
           }
         },
         "zh-Hans" : {
@@ -32662,6 +36280,12 @@
             "value" : "Scuoti per reimpostare"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Встряхнуть для сброса"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32708,6 +36332,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scuoti il telefono durante la riproduzione per reimpostare il timer."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Встряхните телефон во время воспроизведения, чтобы сбросить таймер."
           }
         },
         "zh-Hans" : {
@@ -32758,6 +36388,12 @@
             "value" : "Condividi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поделиться"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32804,6 +36440,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Condividi dettagli connessione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поделиться подключением"
           }
         },
         "zh-Hans" : {
@@ -32854,6 +36496,12 @@
             "value" : "Condividi Link"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поделиться ссылкой"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32900,6 +36548,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Condividi il codice QR"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поделиться QR-кодом"
           }
         },
         "zh-Hans" : {
@@ -32950,6 +36604,12 @@
             "value" : "Condividi questo codice QR o questo link con un altro utente di AudioBooth per aiutarlo a connettersi al tuo server."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поделитесь этим QR-кодом или ссылкой с другим пользователем AudioBooth, чтобы он смог подключиться к вашему серверу"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32996,6 +36656,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La condivisione delle credenziali le invaliderà su questo dispositivo non appena un altro dispositivo le utilizzerà. Per continuare a usare questa connessione, dovrai riconnetterti."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "После того как другое устройство воспользуется этими учётными данными, они перестанут работать на этом устройстве. Чтобы продолжить использовать подключение, потребуется подключиться заново."
           }
         },
         "zh-Hans" : {
@@ -33046,6 +36712,12 @@
             "value" : "Mostra l'avanzamento del libro sotto la barra del capitolo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать прогресс книги под полосой главы"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33092,6 +36764,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostra meno"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Свернуть"
           }
         },
         "zh-Hans" : {
@@ -33142,6 +36820,12 @@
             "value" : "Mostra di più"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать ещё"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33188,6 +36872,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostra l'opzione nel menu dei dettagli del libro per scrivere le informazioni del libro sui tag NFC per un accesso rapido alla riproduzione."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать в меню сведений о книге пункт для записи информации о книге на NFC-метки для быстрого доступа к воспроизведению."
           }
         },
         "zh-Hans" : {
@@ -33238,6 +36928,12 @@
             "value" : "Mostra il tempo rimanente nel titolo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Остаток времени в заголовке"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33284,6 +36980,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostra sottotitolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать подзаголовок"
           }
         },
         "zh-Hans" : {
@@ -33334,6 +37036,12 @@
             "value" : "Mostra la copertina a schermo intero nel player della schermata di blocco"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать обложку во весь экран в плеере на экране блокировки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33380,6 +37088,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostra tempo rimanente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать остаток времени"
           }
         },
         "zh-Hans" : {
@@ -33430,6 +37144,12 @@
             "value" : "Mostra nome utente"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать имя пользователя"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33476,6 +37196,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostra il tempo dell'intero libro invece del capitolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать время всей книги вместо главы"
           }
         },
         "zh-Hans" : {
@@ -33526,6 +37252,12 @@
             "value" : "Mostra il nome utente del server nel titolo Home."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать имя пользователя сервера в заголовке на главной."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33572,6 +37304,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Casuale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемешать"
           }
         },
         "zh-Hans" : {
@@ -33622,6 +37360,12 @@
             "value" : "Salta e riavvolgi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемотка и откат"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33668,6 +37412,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salto e riavvolgimento intelligente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемотка и умный откат"
           }
         },
         "zh-Hans" : {
@@ -33718,6 +37468,12 @@
             "value" : "Indietro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Назад"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33764,6 +37520,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Indietro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмотать назад"
           }
         },
         "zh-Hans" : {
@@ -33814,6 +37576,12 @@
             "value" : "Indietro di %lld secondi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмотать назад на %lld с"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33858,6 +37626,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Indietro di ${duration}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмотать назад на ${duration}"
           }
         },
         "zh-Hans" : {
@@ -33908,6 +37682,12 @@
             "value" : "Indietro per la durata specificata"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмотать назад на заданное время"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33954,6 +37734,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salta per"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Шаг перемотки"
           }
         },
         "zh-Hans" : {
@@ -34004,6 +37790,12 @@
             "value" : "Salta per capitoli"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемотка по главам"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34050,6 +37842,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salta per secondi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемотка по секундам"
           }
         },
         "zh-Hans" : {
@@ -34100,6 +37898,12 @@
             "value" : "Avanti"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемотать вперёд"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34146,6 +37950,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avanti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вперёд"
           }
         },
         "zh-Hans" : {
@@ -34196,6 +38006,12 @@
             "value" : "Salta avanti e indietro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемотка вперёд и назад"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34244,6 +38060,12 @@
             "value" : "Avanti di %lld secondi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемотать вперёд на %lld с"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34288,6 +38110,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avanri di ${duration}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемотать вперёд на ${duration}"
           }
         },
         "zh-Hans" : {
@@ -34338,6 +38166,12 @@
             "value" : "Salta avanti per la durata specificata"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемотать вперёд на заданное время"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34386,6 +38220,12 @@
             "value" : "Salta la schermata iniziale alla riapertura"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пропускать главный экран при повторном открытии"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34396,6 +38236,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新開啟時跳過主畫面"
+          }
+        }
+      }
+    },
+    "Skip to Here" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spring hertil"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hierher springen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saltar aquí"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aller ici"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vai qui"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳转到此处"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳至此處"
           }
         }
       }
@@ -34432,6 +38318,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salta al capitolo successivo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перейти к следующей главе"
           }
         },
         "zh-Hans" : {
@@ -34482,6 +38374,12 @@
             "value" : "Salta al capitolo precedente"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перейти к предыдущей главе"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34528,6 +38426,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salta all’indietro nell’audiolibro in riproduzione di una durata specificata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отматывает назад на заданное время в воспроизводимой аудиокниге."
           }
         },
         "zh-Hans" : {
@@ -34578,6 +38482,12 @@
             "value" : "Salta avanti nell’audiolibro in riproduzione di una durata specificata."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перематывает вперёд на заданное время в воспроизводимой аудиокниге."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34624,6 +38534,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Passa al capitolo successivo dell’audiolibro in riproduzione."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переходит к следующей главе в воспроизводимой аудиокниге."
           }
         },
         "zh-Hans" : {
@@ -34674,6 +38590,12 @@
             "value" : "Passa al capitolo precedente dell’audiolibro in riproduzione."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переходит к предыдущей главе в воспроизводимой аудиокниге."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34720,6 +38642,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Timer di spegnimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер сна"
           }
         },
         "zh-Hans" : {
@@ -34770,6 +38698,12 @@
             "value" : "Sleep-timer"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер сна"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34816,6 +38750,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Timer di sospensione e sveglia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер сна и будильник"
           }
         },
         "zh-Hans" : {
@@ -34866,6 +38806,12 @@
             "value" : "Timer di spegnimento e sveglia"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер сна и будильник"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34912,6 +38858,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sleep-timer annullato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер сна отменён"
           }
         },
         "zh-Hans" : {
@@ -34962,6 +38914,12 @@
             "value" : "Sleep-timer attivo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер сна включен"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35008,6 +38966,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riduci velocità"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Медленнее"
           }
         },
         "zh-Hans" : {
@@ -35058,6 +39022,12 @@
             "value" : "Piccolo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Маленький"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35104,6 +39074,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continuazione intelligente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Умное продолжение"
           }
         },
         "zh-Hans" : {
@@ -35154,6 +39130,12 @@
             "value" : "Riavvolgimento intelligente"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Умный откат"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35200,6 +39182,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Posticipa 5 min"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отложить на 5 мин"
           }
         },
         "zh-Hans" : {
@@ -35250,6 +39238,12 @@
             "value" : "Posticipa o ferma la sveglia."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отложить или остановить будильник."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35296,6 +39290,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ordina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сортировка"
           }
         },
         "zh-Hans" : {
@@ -35346,6 +39346,12 @@
             "value" : "Ordina per"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сортировать по"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35392,6 +39398,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velocità"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скорость"
           }
         },
         "zh-Hans" : {
@@ -35442,6 +39454,12 @@
             "value" : "Aumenta velocità"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Быстрее"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35488,6 +39506,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sponsor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спонсорство"
           }
         },
         "zh-Hans" : {
@@ -35538,6 +39562,12 @@
             "value" : "Standard"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Стандартный"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35584,6 +39614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avvia automaticamente un timer durante la riproduzione."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически запускать таймер во время воспроизведения."
           }
         },
         "zh-Hans" : {
@@ -35634,6 +39670,12 @@
             "value" : "Avvia durante"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запускать в период"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35680,6 +39722,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avvia sleep-timer"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запустить таймер сна"
           }
         },
         "zh-Hans" : {
@@ -35730,6 +39778,12 @@
             "value" : "Iniziato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Начато"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35776,6 +39830,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ferma"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Остановить"
           }
         },
         "zh-Hans" : {
@@ -35826,6 +39886,12 @@
             "value" : "Ferma sveglia"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Остановить будильник"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35872,6 +39938,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Spazio di archiviazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Хранилище"
           }
         },
         "zh-Hans" : {
@@ -35922,6 +39994,12 @@
             "value" : "Stile"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Стиль"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35968,6 +40046,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Abbonati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подписаться"
           }
         },
         "zh-Hans" : {
@@ -36018,6 +40102,12 @@
             "value" : "Lievi vibrazioni sui controlli"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Лёгкая вибрация при нажатиях"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36028,6 +40118,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "控制項上的輕微震動"
+          }
+        }
+      }
+    },
+    "Suggest skipping ahead when you've read further than you've listened" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Foreslå at springe frem, når du har læst længere, end du har lyttet"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorschlagen vorzuspulen, wenn du weiter gelesen als gehört hast"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sugerir avanzar cuando hayas leído más de lo que has escuchado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proposer d'avancer quand vous avez lu plus loin que vous n'avez écouté"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proponi di saltare avanti quando hai letto più di quanto hai ascoltato"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当你阅读的进度超过收听进度时，提示向前跳转"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當你閱讀的進度超過收聽進度時，提示向前跳轉"
           }
         }
       }
@@ -36064,6 +40200,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Barra di avanzamento aggiuntiva"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дополнительная полоса прогресса"
           }
         },
         "zh-Hans" : {
@@ -36114,6 +40256,12 @@
             "value" : "Supporto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поддержка"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36160,6 +40308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SOSTENITORE"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "СПОНСОР"
           }
         },
         "zh-Hans" : {
@@ -36210,6 +40364,12 @@
             "value" : "Scorri per rimuovere o trascina per riordinare"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Смахните, чтобы удалить, или перетащите, чтобы изменить порядок"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36256,6 +40416,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sincronizza"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация"
           }
         },
         "zh-Hans" : {
@@ -36306,6 +40472,12 @@
             "value" : "Sincronizza le tue impostazioni tra tutti i device attraverso iCloud."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизируйте настройки между всеми устройствами через iCloud."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36351,6 +40523,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sistema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системная"
           }
         },
         "zh-Hans" : {
@@ -36401,6 +40579,12 @@
             "value" : "Integrazioni di sistema ed extra"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системные интеграции и дополнения"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36447,6 +40631,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tags"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Теги"
           }
         },
         "zh-Hans" : {
@@ -36497,6 +40687,12 @@
             "value" : "Tocca per navigare"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Навигация касанием"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36543,6 +40739,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tocca per vedere le tue statistiche"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нажмите, чтобы посмотреть статистику"
           }
         },
         "zh-Hans" : {
@@ -36593,6 +40795,12 @@
             "value" : "Tocca per impostare un obiettivo giornaliero"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нажмите, чтобы задать ежедневную цель прослушивания"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36639,6 +40847,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zone di tocco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зоны касания"
           }
         },
         "zh-Hans" : {
@@ -36689,6 +40903,12 @@
             "value" : "Tocca al di fuori delle zone per mostrare o nascondere i controlli"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Касания вне зон показывают или скрывают элементы управления"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36735,6 +40955,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verde acqua"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бирюзовый"
           }
         },
         "zh-Hans" : {
@@ -36785,6 +41011,12 @@
             "value" : "Termini d'uso"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Условия использования"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36833,6 +41065,12 @@
             "value" : "Solo acquisti di prova."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Только тестовые покупки."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36876,6 +41114,12 @@
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TestFlight:"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "TestFlight:"
@@ -36929,6 +41173,12 @@
             "value" : "Normalizzazione del testo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нормализация текста"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36977,6 +41227,12 @@
             "value" : "Grazie per sostenere AudioBooth!"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спасибо за поддержку AudioBooth!"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37023,6 +41279,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Grazie per il tuo supporto !"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спасибо за поддержку!"
           }
         },
         "zh-Hans" : {
@@ -37087,6 +41349,52 @@
         }
       }
     },
+    "The audiobook is about ^[%lld page](inflect: true) ahead." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lydbogen er omkring ^[%lld side](inflect: true) foran."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Hörbuch ist etwa ^[%lld Seite](inflect: true) voraus."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El audiolibro va unas ^[%lld página](inflect: true) por delante."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le livre audio a environ ^[%lld page](inflect: true) d'avance."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'audiolibro è avanti di circa ^[%lld pagina](inflect: true)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有声书大约领先 %lld 页。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有聲書大約領先 %lld 頁。"
+          }
+        }
+      }
+    },
     "The bookmark title" : {
       "comment" : "Request value dialog text for the bookmark title parameter.",
       "isCommentAutoGenerated" : true,
@@ -37119,6 +41427,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il titolo del segnalibro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название закладки"
           }
         },
         "zh-Hans" : {
@@ -37169,6 +41483,12 @@
             "value" : "L'audiolibro corrente non ha capitoli."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В текущей аудиокниге нет глав."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37217,6 +41537,12 @@
             "value" : "La coda viene sempre riprodotta per prima. Le opzioni qui sotto si applicano quando è vuota."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сначала всегда воспроизводится очередь. Параметры ниже действуют, когда она пуста."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37263,6 +41589,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тема"
           }
         },
         "zh-Hans" : {
@@ -37457,6 +41789,12 @@
             "value" : "Questa raccolta è vuota."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Эта подборка пуста."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37601,6 +41939,12 @@
             "value" : "Questa playlist è vuota."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Этот плейлист пуст."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37647,6 +41991,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "questa settimana"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "за эту неделю"
           }
         },
         "zh-Hans" : {
@@ -37697,6 +42047,12 @@
             "value" : "Questo cancellerà tutte le immagini di copertina memorizzate nella cache. Verranno scaricate di nuovo quando necessario."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все кэшированные обложки будут удалены. При необходимости они загрузятся снова."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37743,6 +42099,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Questo eliminerà tutti i contenuti scaricati. Questa azione non può essere annullata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Весь загруженный контент будет удалён. Это действие нельзя отменить."
           }
         },
         "zh-Hans" : {
@@ -37793,6 +42155,12 @@
             "value" : "Tempo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37839,6 +42207,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tempo e avanzamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время и прогресс"
           }
         },
         "zh-Hans" : {
@@ -37889,6 +42263,12 @@
             "value" : "I tempi si adattano alla velocità"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время пересчитывается с учётом скорости"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37935,6 +42315,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Intervallo di tempo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Период времени"
           }
         },
         "zh-Hans" : {
@@ -37985,6 +42371,12 @@
             "value" : "Tempo scaduto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время вышло"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38031,6 +42423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Timer"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер"
           }
         },
         "zh-Hans" : {
@@ -38081,6 +42479,12 @@
             "value" : "Timer completato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер завершён"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38127,6 +42531,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Timer esteso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер продлён"
           }
         },
         "zh-Hans" : {
@@ -38177,6 +42587,12 @@
             "value" : "Il timer non è disponibile."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер недоступен."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38223,6 +42639,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il timer continua il conto alla rovescia mentre la riproduzione è in pausa."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер продолжает идти, пока воспроизведение на паузе."
           }
         },
         "zh-Hans" : {
@@ -38273,6 +42695,12 @@
             "value" : "Il timer si mette in pausa con la riproduzione e riprende alla ripresa."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер приостанавливается вместе с воспроизведением и продолжается при возобновлении."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38319,6 +42747,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il timer è iniziato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер запущен"
           }
         },
         "zh-Hans" : {
@@ -38369,6 +42803,12 @@
             "value" : "Il timer si arresta con la riproduzione e riparte da capo alla ripresa."
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймер останавливается вместе с воспроизведением и запускается заново при возобновлении."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38415,6 +42855,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lascia una mancia per ringraziare e sostenere lo sviluppatore."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поддержите разработчика и скажите спасибо."
           }
         },
         "zh-Hans" : {
@@ -38465,6 +42911,12 @@
             "value" : "Titolo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38511,6 +42963,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "oggi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "сегодня"
           }
         },
         "zh-Hans" : {
@@ -38561,6 +43019,12 @@
             "value" : "Oggi"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сегодня"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38609,6 +43073,12 @@
             "value" : "Inizio della coda"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В начало очереди"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38654,6 +43124,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tocca e tieni premuto per sbloccare"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нажмите и удерживайте, чтобы разблокировать"
           }
         },
         "zh-Hans" : {
@@ -38704,6 +43180,12 @@
             "value" : "Traccie"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дорожки"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38750,6 +43232,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prova ad aggiornare i termini di ricerca"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Попробуйте изменить запрос"
           }
         },
         "zh-Hans" : {
@@ -38800,6 +43288,12 @@
             "value" : "Prova dinuovo"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторить"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38846,6 +43340,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tipografia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Типографика"
           }
         },
         "zh-Hans" : {
@@ -38896,6 +43396,12 @@
             "value" : "Impossibile caricare l'autore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить автора"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38942,6 +43448,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impossibile caricare il libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить книгу"
           }
         },
         "zh-Hans" : {
@@ -38992,6 +43504,12 @@
             "value" : "Impossibile caricare l'ebook"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить электронную книгу"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39038,6 +43556,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impossibile caricare il feed"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить фид"
           }
         },
         "zh-Hans" : {
@@ -39088,6 +43612,12 @@
             "value" : "Impossibile caricare il podcast"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить подкаст"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39136,6 +43666,12 @@
             "value" : "Illimitato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Без ограничений"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39181,6 +43717,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sblocca"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разблокировать"
           }
         },
         "zh-Hans" : {
@@ -39231,6 +43773,12 @@
             "value" : "Rimuovi fissato"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открепить"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39279,6 +43827,12 @@
             "value" : "Deseleziona tutto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Снять выделение"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39289,6 +43843,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消全選"
+          }
+        }
+      }
+    },
+    "Until Next Session" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Til næste gang"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bis zum nächsten Mal"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hasta la próxima sesión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jusqu'à la prochaine session"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fino alla prossima sessione"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直到下次使用"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直到下次使用"
           }
         }
       }
@@ -39325,6 +43925,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "In coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Далее"
           }
         },
         "zh-Hans" : {
@@ -39375,6 +43981,12 @@
             "value" : "Usa la durata del libro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать длительность книги"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39421,6 +44033,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Usa le proporzioni originali di ogni copertina invece di un quadrato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Использовать исходные пропорции обложки вместо квадрата"
           }
         },
         "zh-Hans" : {
@@ -39471,6 +44089,12 @@
             "value" : "Nome utente"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя пользователя"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39517,6 +44141,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nome utente e Password"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя пользователя и пароль"
           }
         },
         "zh-Hans" : {
@@ -39567,6 +44197,12 @@
             "value" : "Verifica e Salva"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверить и сохранить"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39613,6 +44249,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Versione : %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версия: %@"
           }
         },
         "zh-Hans" : {
@@ -39663,6 +44305,12 @@
             "value" : "Molto alto"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очень высокая"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39709,6 +44357,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Molto basso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очень низкая"
           }
         },
         "zh-Hans" : {
@@ -39759,6 +44413,12 @@
             "value" : "Visualizza Autori"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть автора"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39807,6 +44467,12 @@
             "value" : "Visualizza Narratori"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть диктора"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39853,6 +44519,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Visualizza Serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть цикл"
           }
         },
         "zh-Hans" : {
@@ -39949,6 +44621,12 @@
             "value" : "Volume"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Громкость"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39995,6 +44673,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riduci volume"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тише"
           }
         },
         "zh-Hans" : {
@@ -40045,6 +44729,12 @@
             "value" : "Livellamento del volume"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выравнивание громкости"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40093,6 +44783,12 @@
             "value" : "Volume per navigare"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Навигация кнопками громкости"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40139,6 +44835,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aumenta volume"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Громче"
           }
         },
         "zh-Hans" : {
@@ -40281,6 +44983,12 @@
             "value" : "Come deve essere chiamato il segnalibro?"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Как назвать закладку?"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40375,6 +45083,12 @@
             "value" : "Spaziatura carattere"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Межсловный интервал"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40421,6 +45135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scrivi un tag NFC"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Записать NFC-метку"
           }
         },
         "zh-Hans" : {
@@ -40471,6 +45191,12 @@
             "value" : "Revisione annuale"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Итоги года"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40517,6 +45243,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Giallo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жёлтый"
           }
         },
         "zh-Hans" : {
@@ -40567,6 +45299,12 @@
             "value" : "Ieri"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вчера"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40613,6 +45351,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non hai nessuna Playlist"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "У вас нет плейлистов"
           }
         },
         "zh-Hans" : {
@@ -40663,6 +45407,12 @@
             "value" : "Non hai creato nessun segnalibro per questo libro"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы ещё не создали ни одной закладки для этой книги."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40711,6 +45461,12 @@
             "value" : "Sei un sostenitore"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы — спонсор"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40721,6 +45477,98 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你是支持者"
+          }
+        }
+      }
+    },
+    "You've listened about %@ further than you've read." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du har lyttet omkring %@ længere, end du har læst."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du hast etwa %@ weiter gehört als gelesen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Has escuchado unos %@ más de lo que has leído."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous avez écouté environ %@ de plus que vous n'avez lu."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hai ascoltato circa %@ in più di quanto hai letto."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的收听进度比阅读进度快约 %@。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的收聽進度比閱讀進度快約 %@。"
+          }
+        }
+      }
+    },
+    "You've read about %@ further than you've listened." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du har læst omkring %@ længere, end du har lyttet."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du hast etwa %@ weiter gelesen als gehört."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Has leído unos %@ más de lo que has escuchado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous avez lu environ %@ de plus que vous n'avez écouté."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hai letto circa %@ in più di quanto hai ascoltato."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的阅读进度比收听进度快约 %@。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的閱讀進度比收聽進度快約 %@。"
           }
         }
       }
@@ -40757,6 +45605,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "I tuoi segnalibri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваши закладки"
           }
         },
         "zh-Hans" : {
@@ -40807,6 +45661,12 @@
             "value" : "La tua libreria sembra vuota oppure non hai selezionato nessuna libreria"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Похоже, библиотека пуста или не выбрана."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40853,6 +45713,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La tua libreria sembra non avere autori oppure non hai selezionato nessuna libreria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Похоже, в библиотеке нет авторов или библиотека не выбрана."
           }
         },
         "zh-Hans" : {
@@ -40903,6 +45769,12 @@
             "value" : "La tua libreria sembra non avere nattatori oppure non hai selezionato nessuna libreria"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Похоже, в библиотеке нет дикторов или библиотека не выбрана."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40949,6 +45821,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La tua libreria sembra non avere serie oppure non hai selezionato nessuna libreria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Похоже, в библиотеке нет циклов или библиотека не выбрана."
           }
         },
         "zh-Hans" : {
@@ -41045,6 +45923,12 @@
             "value" : "I tuoi servizi personalizzati appariranno quà"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Здесь появится персональная подборка"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -41091,6 +45975,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La tua cronologia di ascolto apparirà quà"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Здесь появится история воспроизведения."
           }
         },
         "zh-Hans" : {
@@ -41141,6 +46031,12 @@
             "value" : "La tua libreria podcast è vuota"
           }
         },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Библиотека подкастов пуста"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -41187,6 +46083,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le tue statistiche"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваша статистика"
           }
         },
         "zh-Hans" : {


### PR DESCRIPTION
So, this is first PR for Russian localization. More PRs with typos fixes are coming :)

And one more thing:
`variations.plural` (`one` / `few` / `many` / `other`) — these are the counter strings marked `^[%lld book](inflect: true)` and friends. Apple's automatic inflection doesn't produce correct Russian forms, and Russian needs three distinct forms anyway (1 книга / 2 книги / 5 книг), so explicit plural variations are used instead of the inflection markup.